### PR TITLE
refactor decorator controller as part of further understanding

### DIFF
--- a/controller/common/finalizer/finalizer.go
+++ b/controller/common/finalizer/finalizer.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2019 The MayaData Authors.
 Copyright 2018 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,13 +25,20 @@ import (
 	dynamicobject "openebs.io/metac/dynamic/object"
 )
 
-// Manager encapsulates controller logic for dealing with finalizers.
+// Manager encapsulates controller logic for dealing with
+// any specific finalizer.
+//
+// TODO (@amitkumardas) Move this to dynamic pkg to
+// let dynamic pkg be used as a library by other
+// projects
 type Manager struct {
+	// Name of the finalizer that needs to be managed
 	Name    string
 	Enabled bool
 }
 
-// SyncObject adds or removes the finalizer on the given object as necessary.
+// SyncObject adds or removes the finalizer on the given object
+// as necessary.
 func (m *Manager) SyncObject(
 	client *dynamicclientset.ResourceClient,
 	obj *unstructured.Unstructured,
@@ -52,8 +60,9 @@ func (m *Manager) SyncObject(
 	return client.Namespace(obj.GetNamespace()).RemoveFinalizer(obj, m.Name)
 }
 
-// ShouldFinalize returns true if the controller should take action to manage
-// children even though the parent is pending deletion (i.e. finalize).
+// ShouldFinalize returns true if the controller should take action
+// to manage children even though the parent is pending deletion
+// (i.e. finalize).
 func (m *Manager) ShouldFinalize(parent metav1.Object) bool {
 	// There's no point managing children if the parent has a GC finalizer,
 	// because we'd be fighting the GC.

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -70,7 +70,7 @@ type parentController struct {
 func newParentController(
 	resources *dynamicdiscovery.ResourceMap,
 	dynClient *dynamicclientset.Clientset,
-	dynInformers *dynamicinformer.SharedInformerFactory,
+	informerFactory *dynamicinformer.SharedInformerFactory,
 	mcClient mcclientset.Interface,
 	revisionLister mclisters.ControllerRevisionLister,
 	cc *v1alpha1.CompositeController,
@@ -91,7 +91,7 @@ func newParentController(
 	}
 
 	// Create informer for the parent resource.
-	parentInformer, err := dynInformers.Resource(
+	parentInformer, err := informerFactory.GetOrCreate(
 		cc.Spec.ParentResource.APIVersion,
 		cc.Spec.ParentResource.Resource,
 	)
@@ -112,7 +112,10 @@ func newParentController(
 		}
 	}()
 	for _, child := range cc.Spec.ChildResources {
-		childInformer, err := dynInformers.Resource(child.APIVersion, child.Resource)
+		childInformer, err := informerFactory.GetOrCreate(
+			child.APIVersion,
+			child.Resource,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("can't create informer for child resource: %v", err)
 		}

--- a/controller/decorator/hooks.go
+++ b/controller/decorator/hooks.go
@@ -48,7 +48,7 @@ type SyncHookResponse struct {
 }
 
 func (c *decoratorController) callSyncHook(request *SyncHookRequest) (*SyncHookResponse, error) {
-	if c.dc.Spec.Hooks == nil {
+	if c.api.Spec.Hooks == nil {
 		return nil, fmt.Errorf("no hooks defined")
 	}
 
@@ -62,21 +62,21 @@ func (c *decoratorController) callSyncHook(request *SyncHookRequest) (*SyncHookR
 	// when the object no longer matches our decorator selector.
 	// This allows the decorator to clean up after itself if the object has been
 	// updated to disable the functionality added by the decorator.
-	if c.dc.Spec.Hooks.Finalize != nil &&
+	if c.api.Spec.Hooks.Finalize != nil &&
 		(request.Object.GetDeletionTimestamp() != nil || !c.parentSelector.Matches(request.Object)) {
 		// Finalize
 		request.Finalizing = true
-		if err := hooks.Call(c.dc.Spec.Hooks.Finalize, request, &response); err != nil {
+		if err := hooks.Call(c.api.Spec.Hooks.Finalize, request, &response); err != nil {
 			return nil, fmt.Errorf("finalize hook failed: %v", err)
 		}
 	} else {
 		// Sync
 		request.Finalizing = false
-		if c.dc.Spec.Hooks.Sync == nil {
+		if c.api.Spec.Hooks.Sync == nil {
 			return nil, fmt.Errorf("sync hook not defined")
 		}
 
-		if err := hooks.Call(c.dc.Spec.Hooks.Sync, request, &response); err != nil {
+		if err := hooks.Call(c.api.Spec.Hooks.Sync, request, &response); err != nil {
 			return nil, fmt.Errorf("sync hook failed: %v", err)
 		}
 	}

--- a/controller/decorator/metacontroller.go
+++ b/controller/decorator/metacontroller.go
@@ -159,7 +159,7 @@ func (mc *Metacontroller) sync(key string) error {
 func (mc *Metacontroller) syncDecoratorController(dc *v1alpha1.DecoratorController) error {
 	if c, ok := mc.decoratorControllers[dc.Name]; ok {
 		// The controller was already started.
-		if apiequality.Semantic.DeepEqual(dc.Spec, c.dc.Spec) {
+		if apiequality.Semantic.DeepEqual(dc.Spec, c.api.Spec) {
 			// Nothing has changed.
 			return nil
 		}

--- a/dynamic/clientset/clientset.go
+++ b/dynamic/clientset/clientset.go
@@ -30,9 +30,9 @@ import (
 	dynamicobject "openebs.io/metac/dynamic/object"
 )
 
-// Clientset exposes various operations against any API resource.
-// This is also known as dynamic client since it can cater to
-// any API resource kind and version.
+// Clientset manages various k8s client related operations against one
+// or more discovered API resource(s). Clientset has the ability to
+// provide dynamic client for specific resource.
 type Clientset struct {
 	config    rest.Config
 	resources *dynamicdiscovery.ResourceMap

--- a/dynamic/informer/factory.go
+++ b/dynamic/informer/factory.go
@@ -52,7 +52,7 @@ func NewSharedInformerFactory(
 	}
 }
 
-// Resource returns a dynamic informer and lister for the given resource.
+// GetOrCreate returns a dynamic informer and lister for the given resource.
 // These are shared with any other controllers in the same process that
 // request the same resource.
 //
@@ -60,7 +60,7 @@ func NewSharedInformerFactory(
 // Close() on the returned ResourceInformer when they no longer need it.
 // Shared informers that become unused will be stopped to minimize our load on
 // the API server.
-func (f *SharedInformerFactory) Resource(apiVersion, resource string) (*ResourceInformer, error) {
+func (f *SharedInformerFactory) GetOrCreate(apiVersion, resource string) (*ResourceInformer, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 

--- a/dynamic/informer/informer.go
+++ b/dynamic/informer/informer.go
@@ -98,8 +98,10 @@ func (ri *ResourceInformer) Close() {
 // sharedResourceInformer is the actual, single informer that's shared by
 // multiple ResourceInformer instances.
 type sharedResourceInformer struct {
+	// informer to the specific API resource
 	informer cache.SharedIndexInformer
-	lister   *dynamiclister.Lister
+	// lister to the specific API resource
+	lister *dynamiclister.Lister
 
 	defaultResyncPeriod time.Duration
 
@@ -153,7 +155,9 @@ type sharedEventHandler struct {
 	handlers map[*informerWrapper][]*eventHandler
 }
 
-func newSharedEventHandler(lister *dynamiclister.Lister, relistPeriod time.Duration) *sharedEventHandler {
+func newSharedEventHandler(
+	lister *dynamiclister.Lister, relistPeriod time.Duration,
+) *sharedEventHandler {
 	return &sharedEventHandler{
 		lister:       lister,
 		relistPeriod: relistPeriod,
@@ -163,7 +167,11 @@ func newSharedEventHandler(lister *dynamiclister.Lister, relistPeriod time.Durat
 
 // addHandler adds a subscriber, remembering which informerWrapper it came from.
 // This lets us easily remove all handlers added through the same source.
-func (seh *sharedEventHandler) addHandler(iw *informerWrapper, handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+func (seh *sharedEventHandler) addHandler(
+	iw *informerWrapper,
+	handler cache.ResourceEventHandler,
+	resyncPeriod time.Duration,
+) {
 	seh.mutex.Lock()
 	defer seh.mutex.Unlock()
 


### PR DESCRIPTION
This commit adds code level comments, renames a few variables as part of deeper understanding of decorator controller. This has been done to reduce the steep learning curve required by contributors to understand and use this controller/library.

This is part of a series of commits that will lead to implementing unit tests as well re-packaging dynamic package to enable using the same as a library in other projects.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>