### PR TITLE
change the examples/service-per-pod to work with metac

### DIFF
--- a/docs/_guide/troubleshooting.md
+++ b/docs/_guide/troubleshooting.md
@@ -36,6 +36,7 @@ Metacontroller will log the following events based on log levels:
 
 ### Common Log Messages
 
+#### Errors due to new CRDs
 Since API discovery info is refreshed periodically, you may see log messages
 like this when you start a controller that depends on a recently-installed CRD:
 
@@ -47,6 +48,7 @@ Usually, this should fix itself within about 30s when the new CRD is discovered.
 If this message continues indefinitely, check that the resource name and API
 group/version are correct.
 
+#### Messages due to periodic flush
 You may also notice periodic log messages like this:
 
 ```
@@ -56,6 +58,20 @@ Watch close - *unstructured.Unstructured total <X> items received
 This comes from the underlying client-go library, and just indicates when the
 shared caches are periodically flushed to place an upper bound on cache
 inconsistency due to potential silent failures in long-running watches.
+
+#### Errors connecting to WebHook service
+
+```
+E1001 06:41:20.115843       1 controller.go:330] failed to sync service-per-pod "apps/v1:StatefulSet:default:nginx": Sync hook failed: Webhook url=http://jsonnetd.metac/sync-service-per-pod timeout=10000000000: Invoke failed: Post http://jsonnetd.metac/sync-service-per-pod: dial tcp: lookup jsonnetd.metac on 127.0.0.53:53: read udp 127.0.0.1:38446->127.0.0.53:53: read: connection refused
+```
+- Check the services of your Kubernetes cluster
+- I got above error while trying with micro.kubectl
+
+```
+E1001 07:21:35.763117       1 controller.go:330] failed to sync pod-name-label "v1:Pod:default:nginx-2": can't update Pod default/nginx-2: Operation cannot be fulfilled on pods "nginx-2": the object has been modified; please apply your changes to the latest version and try again
+```
+- <To fill up>
+
 
 ## Webhook Logs
 

--- a/examples/service-per-pod/README.md
+++ b/examples/service-per-pod/README.md
@@ -47,11 +47,31 @@ is removed to opt out of the decorator, any Services created will be cleaned up.
 * Kubernetes 1.8+ is recommended for its improved CRD support, especially garbage collection.
 * Install Metac using yamls from manifests folder
 
+```sh
+# cd to metac's root folder
+
+kubectl apply -f ./manifests/metacontroller-namespace.yaml
+kubectl apply -f ./manifests/metacontroller-rbac.yaml
+kubectl apply -f ./manifests/metacontroller.yaml
+
+kubectl get crd
+```
+
 ### Deploy the DecoratorControllers
 
 ```sh
+# cd to examples/service-per-pod/
+
+# any change in any of the hooks should be accompanied
+# by deleting configmap & operator & re-applying the same
 kubectl create configmap service-per-pod-hooks -n metac --from-file=hooks
-kubectl apply -f service-per-pod.yaml
+kubectl apply -f operator.yaml
+
+# verify
+kubectl get dctl
+kubectl get cm -n metac
+kubectl get deploy -n metac
+kubectl get svc -n metac
 ```
 
 ### Create an Example StatefulSet

--- a/examples/service-per-pod/my-statefulset.yaml
+++ b/examples/service-per-pod/my-statefulset.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: nginx

--- a/examples/service-per-pod/operator.yaml
+++ b/examples/service-per-pod/operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: service-per-pod
 spec:
   resources:
-  - apiVersion: apps/v1beta1
+  - apiVersion: apps/v1
     resource: statefulsets
     annotationSelector:
       matchExpressions:
@@ -16,10 +16,10 @@ spec:
   hooks:
     sync:
       webhook:
-        url: http://service-per-pod.metac/sync-service-per-pod
+        url: http://jsonnetd.metac/sync-service-per-pod
     finalize:
       webhook:
-        url: http://service-per-pod.metac/finalize-service-per-pod
+        url: http://jsonnetd.metac/finalize-service-per-pod
 ---
 apiVersion: metac.openebs.io/v1alpha1
 kind: DecoratorController
@@ -38,22 +38,22 @@ spec:
   hooks:
     sync:
       webhook:
-        url: http://service-per-pod.metac/sync-pod-name-label
+        url: http://jsonnetd.metac/sync-pod-name-label
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: service-per-pod
+  name: jsonnetd
   namespace: metac
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: service-per-pod
+      app: jsonnetd
   template:
     metadata:
       labels:
-        app: service-per-pod
+        app: jsonnetd
     spec:
       containers:
       - name: hooks
@@ -68,16 +68,20 @@ spec:
       volumes:
       - name: hooks
         configMap:
+          # this configmap provides the jsonnet files that
+          # get executed as webhooks
           name: service-per-pod-hooks
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: service-per-pod
+  # this name is used to build the webhook url
+  name: jsonnetd
+  # this namespace is used to build the webhook url
   namespace: metac
 spec:
   selector:
-    app: service-per-pod
+    app: jsonnetd
   ports:
   - port: 80
     targetPort: 8080

--- a/examples/service-per-pod/test.sh
+++ b/examples/service-per-pod/test.sh
@@ -25,14 +25,14 @@ trap cleanup EXIT
 
 finalizer="protect.dctl.metac.openebs.io/service-per-pod-test"
 
-echo -e "\n++ Installing meta controllers & webhook service"
+echo -e "\n++ Installing decorator controllers & webhook service"
 kubectl create configmap service-per-pod-hooks -n metac --from-file=hooks
-kubectl apply -f service-per-pod.yaml
+kubectl apply -f operator.yaml
 
 echo -e "\n++ Applying STS that will get watched by metac"
 kubectl apply -f my-statefulset.yaml
 
-echo -e "\n++ Waiting for per-pod Service..."
+echo -e "\n++ Waiting for per-pod service..."
 until [[ "$(kubectl get svc nginx-2 -o 'jsonpath={.spec.selector.pod-name}')" == "nginx-2" ]]; \
   do echo "++ Will retry" && sleep 1; \
 done


### PR DESCRIPTION
This is the first of changes w.r.t examples folder that makes use of metac. There will be similar changes that needs to be done to rest of the examples to comply with metac.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>