### PR TITLE
add integration test for clean un-install use case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ integration-dependencies:
 # This can be run on one's laptop or Travis like CI environments.
 .PHONY: integration-test
 integration-test: generated_files integration-dependencies
-	@PATH="$(PWD)/hack/bin:$(PATH)" go test ./test/integration/... -v -timeout 5m -args --logtostderr -v=4
+	@PATH="$(PWD)/hack/bin:$(PATH)" go test ./test/integration/... -v -timeout 5m -args --logtostderr -v=1

--- a/TODO
+++ b/TODO
@@ -1,11 +1,17 @@
 ### TODO:
+- test metac with changes to rbac
+
 - gctl add integration tests:
     - check if finalizer works
     - check if attachments not created by gctl are not updated
     - check if attachments not created by gctl are not deleted
     - check if ReadOnly works
     - check if UpdateAny works
+    - check if DeleteAny works
     - check if same watch can update an attachment via multiple gctl specs
+    - check for 2-way merge as well as 3-way merge
+        - default to 2-way merge if only finalize hook is present
+        - default to 3-way merge if both sync & finalize hooks are present
 
 - gctl - read & review
     - https://github.com/GoogleCloudPlatform/metacontroller/issues/98

--- a/apis/metacontroller/v1alpha1/types_generic.go
+++ b/apis/metacontroller/v1alpha1/types_generic.go
@@ -77,7 +77,10 @@ type GenericControllerSpec struct {
 	//
 	// NOTE:
 	//	This is optional. However this should not be set to true if
-	// UpdateAny is set to true.
+	// UpdateAny or DeleteAny is set to true.
+	//
+	// NOTE:
+	// 	ReadOnly overrides UpdateAny and DeleteAny tunables
 	ReadOnly *bool `json:"readOnly,omitempty"`
 
 	// UpdateAny enables this controller to execute update operations
@@ -93,6 +96,20 @@ type GenericControllerSpec struct {
 	//	This is optional. However this should not be set to true if
 	// ReadOnly is set to true.
 	UpdateAny *bool `json:"updateAny,omitempty"`
+
+	// DeleteAny enables this controller to execute delete operations
+	// against any attachments.
+	//
+	// NOTE:
+	//	This tunable changes the default working mode of GenericController.
+	// When set to true, the controller instance is granted with the
+	// permission to delete any attachments even if these attachments
+	// were not created by this controller instance.
+	//
+	// NOTE:
+	//	This is optional. However this should not be set to true if
+	// ReadOnly is set to true.
+	DeleteAny *bool `json:"deleteAny,omitempty"`
 
 	// Parameters represent a set of key value pairs that can be used by
 	// the sync hook implementation logic.

--- a/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
@@ -842,6 +842,11 @@ func (in *GenericControllerSpec) DeepCopyInto(out *GenericControllerSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeleteAny != nil {
+		in, out := &in.DeleteAny, &out.DeleteAny
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Parameters != nil {
 		in, out := &in.Parameters, &out.Parameters
 		*out = make(map[string]string, len(*in))

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -44,9 +44,41 @@ var (
 // instances in a way that is easy to find / filter later.
 type AnyUnstructRegistry map[string]map[string]*unstructured.Unstructured
 
+// String implements Stringer interface
+func (m AnyUnstructRegistry) String() string {
+	var message []string
+	title := "Resource Instances:-"
+	for vk, list := range m {
+		for nsname, obj := range list {
+			message = append(message, fmt.Sprintf("\t%s:%s %s", vk, nsname, obj.GetUID()))
+		}
+	}
+	return fmt.Sprintf("%s\n%s\n", title, strings.Join(message, "\n"))
+}
+
 // IsEmpty returns true if this registry is empty
 func (m AnyUnstructRegistry) IsEmpty() bool {
-	return len(m) == 0
+	for _, list := range m {
+		for _, obj := range list {
+			if obj != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Len returns count of not nil items in this registry
+func (m AnyUnstructRegistry) Len() int {
+	var count int
+	for _, list := range m {
+		for _, obj := range list {
+			if obj != nil {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 // InitGroupByVK initialises (or re-initializes) a group within the

--- a/controller/common/hooks.go
+++ b/controller/common/hooks.go
@@ -29,7 +29,7 @@ import (
 // caller logic based on the provided schema
 //
 // NOTE:
-//	This logic is expected to have multiple if conditions to support
+//	This logic is expected to have multiple **if conditions** to support
 // different hook types e.g. Webhook, gRPCHook, GoTemplateHook etc
 // when they are supported in future
 func SetCallFnFromSchema(schema *v1alpha1.Hook) hooks.HookCallerOption {

--- a/controller/generic/options.go
+++ b/controller/generic/options.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+)
+
+// Option represents the functional way to construct an
+// instance of v1alpha1.GenericController
+//
+// This follows a functional option pattern
+type Option func(*v1alpha1.GenericController)
+
+// WithReadOnly sets the GenericController instance's
+// ReadOnly option with the provided boolean
+func WithReadOnly(b *bool) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		ctl.Spec.ReadOnly = b
+	}
+}
+
+// WithUpdateAny sets the GenericController instance's
+// UpdateAny option with the provided boolean
+func WithUpdateAny(b *bool) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		ctl.Spec.UpdateAny = b
+	}
+}
+
+// WithDeleteAny sets the GenericController instance's
+// DeleteAny option with the provided boolean
+func WithDeleteAny(b *bool) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		ctl.Spec.DeleteAny = b
+	}
+}
+
+// WithWebhookSyncURL sets the GenericController instance's
+// Webhook sync url
+func WithWebhookSyncURL(url *string) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		if url == nil {
+			return
+		}
+		if ctl.Spec.Hooks == nil {
+			ctl.Spec.Hooks = &v1alpha1.GenericControllerHooks{}
+		}
+		if ctl.Spec.Hooks.Sync == nil {
+			ctl.Spec.Hooks.Sync = &v1alpha1.Hook{}
+		}
+		ctl.Spec.Hooks.Sync.Webhook = &v1alpha1.Webhook{
+			URL: url,
+		}
+	}
+}
+
+// WithWebhookFinalizeURL sets the GenericController instance's
+// Webhook sync url
+func WithWebhookFinalizeURL(url *string) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		if url == nil {
+			return
+		}
+		if ctl.Spec.Hooks == nil {
+			ctl.Spec.Hooks = &v1alpha1.GenericControllerHooks{}
+		}
+		if ctl.Spec.Hooks.Finalize == nil {
+			ctl.Spec.Hooks.Finalize = &v1alpha1.Hook{}
+		}
+		ctl.Spec.Hooks.Finalize.Webhook = &v1alpha1.Webhook{
+			URL: url,
+		}
+	}
+}
+
+// WithWatch sets the provided watch against the GenericController
+// instance
+func WithWatch(watch *v1alpha1.GenericControllerResource) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		if watch == nil {
+			return
+		}
+		ctl.Spec.Watch = *watch
+	}
+}
+
+// WithWatchRule sets the watch along with its rules against the
+// provided GenericController instance
+func WithWatchRule(rule *v1alpha1.ResourceRule) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		if rule == nil {
+			return
+		}
+		ctl.Spec.Watch = v1alpha1.GenericControllerResource{
+			ResourceRule: *rule,
+		}
+	}
+}
+
+// WithAttachmentRules sets the watch along with its rules against the
+// provided GenericController instance
+func WithAttachmentRules(rules []*v1alpha1.ResourceRule) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		attachments := []v1alpha1.GenericControllerAttachment{}
+		for _, rule := range rules {
+			if rule == nil {
+				continue
+			}
+			attachments = append(
+				attachments,
+				v1alpha1.GenericControllerAttachment{
+					GenericControllerResource: v1alpha1.GenericControllerResource{
+						ResourceRule: *rule,
+					},
+				},
+			)
+		}
+
+		ctl.Spec.Attachments = attachments
+	}
+}
+
+// WithAttachments sets the watch along with its rules against the
+// provided GenericController instance
+func WithAttachments(atts []*v1alpha1.GenericControllerAttachment) Option {
+	return func(ctl *v1alpha1.GenericController) {
+		for _, att := range atts {
+			if att == nil {
+				continue
+			}
+			ctl.Spec.Attachments = append(ctl.Spec.Attachments, *att)
+		}
+	}
+}

--- a/controller/generic/updatestrategy.go
+++ b/controller/generic/updatestrategy.go
@@ -19,7 +19,7 @@ package generic
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/golang/glog"
 
 	"openebs.io/metac/apis/metacontroller/v1alpha1"
 	"openebs.io/metac/controller/common"
@@ -94,12 +94,14 @@ func newAttachmentUpdateStrategyManager(
 			// this is done to map resource name to kind name
 			resource := resourceMgr.GetByResource(attachment.APIVersion, attachment.Resource)
 			if resource == nil {
-				return nil, errors.Errorf(
-					"%s: Can't find resource %s/%s",
-					mgr,
-					attachment.APIVersion,
-					attachment.Resource,
-				)
+				if glog.V(2) {
+					glog.Warningf("%s: Can't find resource %s/%s",
+						mgr,
+						attachment.APIVersion,
+						attachment.Resource,
+					)
+				}
+				continue
 			}
 			// Ignore API version.
 			apiGroup, _ := common.ParseAPIVersionToGroupVersion(attachment.APIVersion)

--- a/docs/_guide/troubleshooting.md
+++ b/docs/_guide/troubleshooting.md
@@ -27,12 +27,13 @@ At all log levels, Metacontroller will log the progress of server startup and
 shutdown, as well as major changes like starting and stopping hosted controllers.
 
 Metacontroller will log the following events based on log levels:
-- level 1: startup, shutdown, error, create & delete actions
-- level 2: update actions
-- level 3: ignore/skip actions due to specifics
-- level 4: creating, updating, deleting, debugging, ignore/skip actions due to defaults
+- level 1: startup, shutdown, error, created & deleted events
+- level 2: updated, warning events
+- level 3: synced, finalized, ignore/skip actions due to user specified values
+- level 4: syncing, finalizing, creating, updating, deleting, debugging, ignore/skip actions due to defaults
 - level 5: diff of objects
 - level 6: hook invocation along with JSON req & response bodies
+- level 7: resource discovery
 
 ### Common Log Messages
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.12
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
+	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.3.0
 	github.com/google/go-jsonnet v0.13.0
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4 h1:bRzFpEzvausOAt4va+I/22BZ1vXDtERngp0BNYDKej0=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -338,6 +339,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058 h1:di3XCwddOR9cWBNpfgXaskhh6cgJuwcK54rvtwUaC10=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=

--- a/test/integration/framework/helper.go
+++ b/test/integration/framework/helper.go
@@ -17,11 +17,32 @@ limitations under the License.
 package framework
 
 import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
+
 	"openebs.io/metac/apis/metacontroller/v1alpha1"
 )
+
+// PrettyYml returns yaml formatted string corresponding
+// to the given object
+func PrettyYml(obj runtime.Object) string {
+	if obj == nil {
+		return fmt.Sprintf("\n{nil}")
+	}
+
+	b, err := yaml.Marshal(obj)
+	if err != nil {
+		// swallow the error
+		return fmt.Sprintf("\n%v", obj)
+	}
+
+	return fmt.Sprintf("\n%s", string(b))
+}
 
 // BuildUnstructObjFromCRD builds an unstructured instance
 // from the given CRD instance
@@ -35,7 +56,7 @@ func BuildUnstructObjFromCRD(
 	obj.SetAPIVersion(crd.Spec.Group + "/" + crd.Spec.Versions[0].Name)
 	obj.SetKind(crd.Spec.Names.Kind)
 
-	// resource set is only set
+	// resource name is only set
 	obj.SetName(name)
 	return obj
 }

--- a/test/integration/generic/generic_test.go
+++ b/test/integration/generic/generic_test.go
@@ -30,6 +30,7 @@ import (
 	"openebs.io/metac/apis/metacontroller/v1alpha1"
 	"openebs.io/metac/controller/generic"
 	"openebs.io/metac/test/integration/framework"
+	k8s "openebs.io/metac/third_party/kubernetes"
 )
 
 // This will be run only once when go test is invoked against this package.
@@ -105,9 +106,13 @@ func TestGCtlSyncWebhook(t *testing.T) {
 	f.CreateGenericController(
 		testName,
 		ns.Name,
-		hook.URL,
-		framework.BuildResourceRuleFromCRD(watchCRD),
-		framework.BuildResourceRuleFromCRD(attachmentCRD),
+		generic.WithWebhookSyncURL(k8s.StringPtr(hook.URL)),
+		generic.WithAttachmentRules(
+			[]*v1alpha1.ResourceRule{
+				framework.BuildResourceRuleFromCRD(attachmentCRD),
+			},
+		),
+		generic.WithWatchRule(framework.BuildResourceRuleFromCRD(watchCRD)),
 	)
 
 	watchResource := framework.BuildUnstructObjFromCRD(watchCRD, testName)
@@ -211,9 +216,15 @@ func TestGCtlCascadingDelete(t *testing.T) {
 	f.CreateGenericController(
 		controllerName,
 		ns.Name,
-		hook.URL,
-		framework.BuildResourceRuleFromCRD(watchCRD),
-		&v1alpha1.ResourceRule{APIVersion: "batch/v1", Resource: "jobs"},
+		generic.WithWebhookSyncURL(k8s.StringPtr(hook.URL)),
+		generic.WithWatchRule(
+			framework.BuildResourceRuleFromCRD(watchCRD),
+		),
+		generic.WithAttachmentRules(
+			[]*v1alpha1.ResourceRule{
+				&v1alpha1.ResourceRule{APIVersion: "batch/v1", Resource: "jobs"},
+			},
+		),
 	)
 
 	watchResource := framework.BuildUnstructObjFromCRD(watchCRD, resourceName)
@@ -344,9 +355,10 @@ func TestGCtlResyncAfter(t *testing.T) {
 	f.CreateGenericController(
 		testName,
 		ns.Name,
-		hook.URL,
-		framework.BuildResourceRuleFromCRD(watchCRD),
-		nil,
+		generic.WithWebhookSyncURL(k8s.StringPtr(hook.URL)),
+		generic.WithWatchRule(
+			framework.BuildResourceRuleFromCRD(watchCRD),
+		),
 	)
 
 	watchResource := framework.BuildUnstructObjFromCRD(watchCRD, testName)

--- a/test/integration/generic/ns_crd_uninstall_test.go
+++ b/test/integration/generic/ns_crd_uninstall_test.go
@@ -1,0 +1,488 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+	"openebs.io/metac/controller/generic"
+	"openebs.io/metac/test/integration/framework"
+	k8s "openebs.io/metac/third_party/kubernetes"
+)
+
+// TestUnInstallOfNSAndCRDs will verify if GenericController can be
+// used to implement clean uninstall requirements.
+//
+// A clean uninstall implies when a workload specific namespace
+// is removed from kubernetes cluster, the associated CRDs and CRs
+// should get removed from this cluster. This should work even in
+// the cases where CRs are set with finalizers and the corresponding
+// controllers i.e. pods are no longer available due to the deletion
+// of this workload namespace.
+func TestUnInstallOfNSAndCRDs(t *testing.T) {
+	// namespace to setup GenericController
+	ctlNSNamePrefix := "gctl-test"
+	// name of the GenericController
+	ctlName := "clean-uninstall-ctrl"
+
+	// name of the target namespace which is watched by GenericController
+	targetNSName := "target-ns"
+
+	// name of the target resource(s) that are created
+	// and are expected to get deleted upon deletion
+	// of target namespace
+	targetResName := "my-target"
+	finalizers := []string{
+		"protect.abc.io",
+		"protect.def.io",
+		"protect.bc.org",
+	}
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	// create namespace to setup GenericController resources
+	ctlNS := f.CreateNamespaceGen(ctlNSNamePrefix)
+
+	var err error
+
+	// ---------------------------------------------------
+	// Create the target namespace i.e. target under test
+	// ---------------------------------------------------
+	//
+	// NOTE:
+	// 	Targeted CustomResources will be set in this namespace
+	targetNS, err := f.GetTypedClientset().CoreV1().Namespaces().Create(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNSName,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// setup some random CRDs, some of which are cluster scoped
+	// while others are namespace scoped
+
+	// define a cluster scoped CRD & create a dummy resource as well
+	cpcCRD, cpcClient, _ := f.SetupCRDAndDeployOneCR(
+		"CStorPoolClaim",
+		targetResName,
+	)
+	// define a namespace scoped CRD & create a dummy resource as well
+	cvrCRD, cvrClient, _ := f.SetupNSCRDAndDeployOneCR(
+		"CStorVolumeReplica",
+		targetNS.GetName(),
+		targetResName,
+	)
+
+	// ---------------------------------------------------------------
+	// Define the "reconcile logic" for sync i.e. create/update events
+	// ---------------------------------------------------------------
+	//
+	// NOTE:
+	// 	We just set the finalizers to the attachments
+	sHook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := generic.SyncHookRequest{}
+		if uerr := json.Unmarshal(body, &req); uerr != nil {
+			return nil, uerr
+		}
+
+		// initialize the hook response
+		resp := generic.SyncHookResponse{}
+
+		for _, attGroup := range req.Attachments {
+			for _, att := range attGroup {
+				if att == nil {
+					continue
+				}
+				respAtt := att
+				//if len(att.GetFinalizers()) == 0 &&
+				//	att.GetKind() != "CustomResourceDefinition" {
+				if len(att.GetFinalizers()) == 0 && att.GetDeletionTimestamp() == nil {
+					// set finalizers to attachments that are not pending deletion
+					respAtt.SetFinalizers(finalizers)
+				}
+				// keep the attachments that are not pending deletion
+				if att.GetDeletionTimestamp() == nil {
+					resp.Attachments = append(resp.Attachments, respAtt)
+				}
+			}
+		}
+
+		t.Logf(
+			"Sync attachments count: Req %d: Resp %d",
+			req.Attachments.Len(), len(resp.Attachments),
+		)
+
+		return json.Marshal(resp)
+	})
+
+	// ------------------------------------------------------------
+	// Define the "reconcile logic" for finalize i.e. delete event
+	// ------------------------------------------------------------
+	//
+	// NOTE:
+	// 	This is a multi process reconciliation strategy:
+	//		Stage 1: remove finalizers in first/initial finalize hook(s)
+	//		Stage 2: remove the attachments in subsequent finalize hook(s)
+	//
+	// FUTURE:
+	//	One can report these stages via status of the watch object
+	fHook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := generic.SyncHookRequest{}
+		if uerr := json.Unmarshal(body, &req); uerr != nil {
+			return nil, uerr
+		}
+
+		// initialize the hook response
+		resp := generic.SyncHookResponse{}
+
+		// this check i.e. deletion timestamp is not required
+		// if this hook is set exclusively as a finalize hook
+		if req.Watch.GetDeletionTimestamp() != nil {
+
+			// we shall remove finalizer from custom resources
+			// in first sync i.e. stage 1
+
+			var hasCR bool
+			//var hasFinalizer bool
+			for _, attGroup := range req.Attachments {
+				for _, att := range attGroup {
+					if att == nil {
+						continue
+					}
+
+					if att.GetKind() != "CustomResourceDefinition" {
+						hasCR = true
+					}
+
+					if len(att.GetFinalizers()) == 0 &&
+						att.GetKind() != "CustomResourceDefinition" {
+						// if this is a custom resource & does not have any finalizers
+						// then let this be deleted i.e. don't add to response
+						continue
+					}
+
+					// copy the attachment from req to a new instance
+					respAtt := att
+
+					if len(att.GetFinalizers()) != 0 {
+						//hasFinalizer = true
+						// remove finalizers
+						respAtt.SetFinalizers(nil)
+					}
+
+					// add the updated attachment to response to let this
+					// attachment be updated at cluster
+					resp.Attachments = append(resp.Attachments, respAtt)
+				}
+			}
+
+			//if !hasCR && !hasFinalizer {
+			if !hasCR {
+				// If there are no custom resources & no finalizers in
+				// any attachments then we can set the response attachments
+				// to nil. This implies all CRs are deleted & it is the time
+				// to delete all CRDs.
+				resp.Attachments = nil
+			}
+
+			// keep executing finalize hook till its request has attachments
+			if req.Attachments.IsEmpty() {
+				// since all attachments are deleted from cluster
+				// indicate GenericController to mark completion
+				// of finalize hook
+				resp.Finalized = true
+			} else {
+				// if there are still attachments seen in the request
+				// keep resyncing the watch
+				resp.ResyncAfterSeconds = 2
+			}
+		}
+
+		t.Logf(
+			"Finalize attachments count: Req %d: Resp %d",
+			req.Attachments.Len(), len(resp.Attachments),
+		)
+
+		return json.Marshal(resp)
+	})
+
+	// ---------------------------------------------------------
+	// Define & Apply a GenericController i.e. a Meta Controller
+	// ---------------------------------------------------------
+
+	// This is one of the meta controller that is defined as
+	// a Kubernetes custom resource. It listens to the resource
+	// specified in the watch field and acts against the resources
+	// specified in the attachments field.
+	f.CreateGenericController(
+		ctlName,
+		ctlNS.Name,
+
+		// enable controller to delete any attachments
+		generic.WithDeleteAny(k8s.BoolPtr(true)),
+
+		// enable controller to update any attachments
+		generic.WithUpdateAny(k8s.BoolPtr(true)),
+
+		// set 'sync' as well as 'finalize' hooks
+		generic.WithWebhookSyncURL(&sHook.URL),
+		generic.WithWebhookFinalizeURL(&fHook.URL),
+
+		// We want Namespace as our watched resource
+		generic.WithWatch(
+			&v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "namespaces",
+				},
+				// We are interested only for our target namespace
+				NameSelector: []string{targetNSName},
+			},
+		),
+
+		// We want the CRs & CRDs as our attachments.
+		//
+		// This is done so as to implement clean uninstall when
+		// above watch resource is deleted. A clean uninstall is
+		// successful if these declared attachments get deleted
+		// when watch i.e. our target namespace is deleted.
+		generic.WithAttachments(
+			[]*v1alpha1.GenericControllerAttachment{
+				// We want all CPC custom resources as attachments
+				&v1alpha1.GenericControllerAttachment{
+					GenericControllerResource: v1alpha1.GenericControllerResource{
+						ResourceRule: v1alpha1.ResourceRule{
+							APIVersion: cpcCRD.Spec.Group + "/" + cpcCRD.Spec.Versions[0].Name,
+							Resource:   cpcCRD.Spec.Names.Plural,
+						},
+					},
+					UpdateStrategy: &v1alpha1.GenericControllerAttachmentUpdateStrategy{
+						Method: v1alpha1.ChildUpdateInPlace,
+					},
+				},
+				// We want all CVR custom resources as attachments
+				&v1alpha1.GenericControllerAttachment{
+					GenericControllerResource: v1alpha1.GenericControllerResource{
+						ResourceRule: v1alpha1.ResourceRule{
+							APIVersion: cvrCRD.Spec.Group + "/" + cvrCRD.Spec.Versions[0].Name,
+							Resource:   cvrCRD.Spec.Names.Plural,
+						},
+					},
+					UpdateStrategy: &v1alpha1.GenericControllerAttachmentUpdateStrategy{
+						Method: v1alpha1.ChildUpdateInPlace,
+					},
+				},
+				// We want CRDs to be included as attachments &&
+				// We want only our CRDs i.e. CStorPoolClaim & CStorVolumeReplica
+				&v1alpha1.GenericControllerAttachment{
+					GenericControllerResource: v1alpha1.GenericControllerResource{
+						ResourceRule: v1alpha1.ResourceRule{
+							APIVersion: "apiextensions.k8s.io/v1beta1",
+							Resource:   "customresourcedefinitions",
+						},
+						NameSelector: []string{
+							cpcCRD.GetName(),
+							cvrCRD.GetName(),
+						},
+					},
+					UpdateStrategy: &v1alpha1.GenericControllerAttachmentUpdateStrategy{
+						Method: v1alpha1.ChildUpdateInPlace,
+					},
+				},
+			},
+		),
+	)
+
+	// -------------------------------------------------------
+	// Wait for the setup to behave similar to production env
+	// -------------------------------------------------------
+	//
+	// Wait till target namespace is assigned with a finalizer
+	// by GenericController. GenericController automatically
+	// assigns a watch with its own finalizer if it finds a
+	// finalize hook in its specifications.
+	err = f.Wait(func() (bool, error) {
+		targetNS, err =
+			f.GetTypedClientset().CoreV1().Namespaces().Get(targetNSName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, finalizer := range targetNS.GetFinalizers() {
+			if finalizer == "protect.gctl.metac.openebs.io/"+ctlNS.GetName()+"-"+ctlName {
+				return true, nil
+			}
+		}
+		return false,
+			errors.Errorf("Namespace %s is not set with gctl finalizer", targetNSName)
+
+	})
+	if err != nil {
+		// we wait till timeout & panic if condition is not met
+		t.Fatal(err)
+	}
+
+	// Since setup is ready
+	//
+	// ------------------------------------------------------
+	// Trigger the test by deleting the target namespace
+	// ------------------------------------------------------
+	err = f.GetTypedClientset().CoreV1().Namespaces().
+		Delete(targetNS.GetName(), &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Need to wait & see if our controller works as expected
+	// Make sure the specified attachments are deleted
+	t.Logf("Waiting for deletion of CRs & CRDs")
+
+	err = f.Wait(func() (bool, error) {
+		var errs []error
+		var getErr error
+
+		// -------------------------------------------
+		// verify if our custom resources are deleted
+		// -------------------------------------------
+		cpc, getErr := cpcClient.Get(targetResName, metav1.GetOptions{})
+		if getErr != nil && !apierrors.IsNotFound(getErr) {
+			errs = append(
+				errs,
+				errors.Wrapf(getErr, "Failed to get CPC %s", targetResName),
+			)
+		}
+		if cpc != nil {
+			errs = append(errs, errors.Errorf("CPC %s is not deleted", targetResName))
+		}
+
+		cvr, getErr := cvrClient.Namespace(targetNSName).Get(targetResName, metav1.GetOptions{})
+		if getErr != nil && !apierrors.IsNotFound(getErr) {
+			errs = append(
+				errs,
+				errors.Wrapf(getErr, "Failed to get CVR %s", targetResName),
+			)
+		}
+		if cvr != nil {
+			errs = append(errs, errors.Errorf("CVR %s is not deleted", targetResName))
+		}
+
+		// ---------------------------------------------
+		// verify if our CRDs are deleted
+		// ---------------------------------------------
+
+		// TODO (@amitkumardas):
+		// Not sure why following does not work ?
+		// The logs show that these CRDs are getting deleted
+		// based on above sync & finalize logic. However, below
+		// get calls work always.
+		//
+		// Have commented till I get the root cause!
+		// cpcCRDAgain, getErr := f.GetCRDClient().CustomResourceDefinitions().
+		// 	Get(cpcCRD.GetName(), metav1.GetOptions{})
+		// if getErr != nil && !apierrors.IsNotFound(getErr) {
+		// 	errs = append(errs, getErr)
+		// }
+		// if cpcCRDAgain != nil && len(cpcCRDAgain.GetFinalizers()) != 0 {
+		// 	errs = append(
+		// 		errs,
+		// 		errors.Errorf(
+		// 			"CPC CRD %s has finalizers", cpcCRD.GetName(),
+		// 		),
+		// 	)
+		// }
+		// if cpcCRDAgain != nil && cpcCRDAgain.GetDeletionTimestamp() == nil {
+		// 	errs = append(
+		// 		errs,
+		// 		errors.Errorf(
+		// 			"CPC CRD %s is not marked for deletion", cpcCRD.GetName(),
+		// 		),
+		// 	)
+		// }
+
+		// cvrCRDAgain, getErr := f.GetCRDClient().CustomResourceDefinitions().
+		// 	Get(cvrCRD.GetName(), metav1.GetOptions{})
+		// if getErr != nil && !apierrors.IsNotFound(getErr) {
+		// 	errs = append(errs, getErr)
+		// }
+		// if cvrCRDAgain != nil && len(cvrCRDAgain.GetFinalizers()) != 0 {
+		// 	errs = append(
+		// 		errs,
+		// 		errors.Errorf(
+		// 			"CVR CRD %s has finalizers", cvrCRD.GetName(),
+		// 		),
+		// 	)
+		// }
+		// if cvrCRDAgain != nil && cvrCRDAgain.GetDeletionTimestamp() == nil {
+		// 	errs = append(
+		// 		errs,
+		// 		errors.Errorf(
+		// 			"CVR CRD %s is not marked for deletion", cvrCRD.GetName(),
+		// 		),
+		// 	)
+		// }
+
+		// ------------------------------------------
+		// verify if our target namespace is deleted
+		// ------------------------------------------
+		targetNSAgain, getErr := f.GetTypedClientset().CoreV1().Namespaces().
+			Get(targetNS.GetName(), metav1.GetOptions{})
+		if getErr != nil && !apierrors.IsNotFound(getErr) {
+			errs = append(errs, getErr)
+		}
+		if targetNSAgain != nil && len(targetNSAgain.GetFinalizers()) != 0 {
+			errs = append(
+				errs,
+				errors.Errorf(
+					"Namespace %s has finalizers", targetNS.GetName(),
+				),
+			)
+		}
+		if targetNSAgain != nil && targetNSAgain.GetDeletionTimestamp() == nil {
+			errs = append(
+				errs,
+				errors.Errorf(
+					"Namespace %s is not marked for deletion", targetNS.GetName(),
+				),
+			)
+		}
+
+		// condition did not pass in case of any errors
+		if len(errs) != 0 {
+			return false, utilerrors.NewAggregate(errs)
+		}
+
+		// condition passed
+		return true, nil
+	})
+
+	if err != nil {
+		t.Fatalf("CRs & CRDs deletion failed: %v", err)
+	}
+	t.Logf("CRs & CRDs were finalized / deleted successfully")
+}

--- a/third_party/kubernetes/pointer.go
+++ b/third_party/kubernetes/pointer.go
@@ -16,14 +16,20 @@ package kubernetes
 // This is copied from k8s.io/kubernetes to avoid a dependency on all of Kubernetes.
 // TODO(enisoc): Move the upstream code to somewhere better.
 
-// BoolPtr returns a pointer to a bool
+// BoolPtr returns a pointer to the given bool
 func BoolPtr(b bool) *bool {
 	o := b
 	return &o
 }
 
-// Int32Ptr returns a pointer to an int32
+// Int32Ptr returns a pointer to the given int32
 func Int32Ptr(i int32) *int32 {
 	o := i
+	return &o
+}
+
+// StringPtr returns a pointer to the given string
+func StringPtr(s string) *string {
+	o := s
 	return &o
 }


### PR DESCRIPTION
This commit has fixes and enhancements that were required to implement clean un-install use case. This use case talks about deletion of CRDs and custom resources belonging to a particular workload when that workload's namespace is deleted. This use case takes care of cases where these custom resources might have finalizers set against them.

While this works, there is certainly more amount of work that needs to get into Metac.

Among other things Metac's GenericController needs to be improved further to default to 2-way merge or 3-way merge (kubectl like apply) depending on scenarios. In this particular case, 2-way merge seemed to be a good choice over 3-way merge. Since, Metac does not support 2-way merge, this example had to make use of sync as well as finalize hook to achieve the end goal. Ideal implementation would have been to just make use of finalize hook to solve this requirement.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>