### PR TITLE
[local] add option to run metac from local config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY Makefile Makefile
 # copy source files
 COPY *.go ./
 COPY apis/ apis/
+COPY config/ config/
 COPY hack/ hack/
 COPY controller/ controller/
 COPY dynamic/ dynamic/

--- a/TODO
+++ b/TODO
@@ -31,9 +31,10 @@
     - https://github.com/GoogleCloudPlatform/metacontroller/pull/168
 
 ### Few targeted usecases:
-  - ConformanceTest
-  - CStorConfigController
-  - DDP
+  - K8s ConformanceTest Controllers
+  - K8s Controllers
+  - K8s Debug Controllers
+  - K8s Monitoring Controllers
   - Install
   - UnInstall
   - Upgrade
@@ -63,3 +64,28 @@
 ### Meeting Notes & Agenda
 - https://docs.google.com/document/d/1HV_Fr0wIW9tr5OZwK_6oGux_OhcGtxxWWV6dCYJR9Cw/
 
+
+### Updated TODO List With Priority
+- Apply via Update support - 5
+    - Unit Test 3-way merge
+    - Unit Test 2-way merge
+    - Check if 3-way can be converted to 2-way merge on some condition
+- Skip Reconcile support - 2
+- Advanced Selector support - 6
+    - study existing implementation; push more code comments
+    - study existing unit tests; push more code comments
+    - look again at the names of key, operator, etc;
+    - implement the required stuff
+- Local config based execution - 1
+    - Read existing changes; push more code comments
+    - Send PR
+- Local config based examples - 7
+- Local config based integration tests - 8
+- Namespace controlled execution - 3
+- Allowed-namespaces based flag - 4
+- Send specific parts of attachments - 9
+    - e.g. namespace & name, metadata only, status only, metadata + spec, labels only, annotations only, 
+    - examples - 10
+    - integration tests - 11
+- Simplify Integration Tests - ?
+    - refer to apiserver-extensions project

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+	k8s "openebs.io/metac/third_party/kubernetes"
+)
+
+// MetacConfigs represents unmarshaled form of all
+// the config files provided to run Metac controllers
+type MetacConfigs []unstructured.Unstructured
+
+// ListGenericControllers returns all GenericController configs
+func (mc MetacConfigs) ListGenericControllers() ([]*v1alpha1.GenericController, error) {
+	var gctls []*v1alpha1.GenericController
+	for _, u := range mc {
+		if u.GetKind() != "GenericController" {
+			continue
+		}
+		raw, err := u.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		gctl := v1alpha1.GenericController{}
+		if err := json.Unmarshal(raw, &gctl); err != nil {
+			return nil, err
+		}
+		gctls = append(gctls, &gctl)
+	}
+	return gctls, nil
+}
+
+// Config is the path to metac's Config files
+type Config struct {
+	Path string
+}
+
+// New returns a new instance of config
+func New(path string) *Config {
+	return &Config{path}
+}
+
+// Load loads all metac config files & converts them
+// to unstructured instances
+func (c *Config) Load() (MetacConfigs, error) {
+	files, readerr := ioutil.ReadDir(c.Path)
+	if readerr != nil {
+		return nil, readerr
+	}
+
+	var out MetacConfigs
+	var loaderr error
+
+	// there can be multiple config files
+	for _, file := range files {
+		f, openerr := os.Open(file.Name())
+		if openerr != nil {
+			glog.Errorf("Failed to open metac config file %s: %v", file.Name(), openerr)
+			return nil, openerr
+		}
+		defer func() {
+			if loaderr != nil {
+				glog.Errorf("%v", loaderr)
+			}
+			if closeerr := f.Close(); closeerr != nil {
+				glog.Fatal(closeerr)
+			}
+		}()
+
+		var buffer bytes.Buffer
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			buffer.Write(s.Bytes())
+		}
+		if loaderr = s.Err(); loaderr != nil {
+			loaderr = errors.Wrapf(loaderr, "Failed to load metac config %s", file.Name())
+			return nil, loaderr
+		}
+
+		ul, loaderr := k8s.YAMLToUnstructuredSlice(buffer.Bytes())
+		if loaderr != nil {
+			loaderr = errors.Wrapf(loaderr, "Failed to load metac config %s", file.Name())
+			return nil, loaderr
+		}
+		out = append(out, ul...)
+	}
+	return out, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	k8s "openebs.io/metac/third_party/kubernetes"
+)
+
+func TestMetacConfigsListGeneric(t *testing.T) {
+	ul, err := k8s.YAMLToUnstructuredSlice([]byte(`
+---
+---
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: install-un-crd
+spec:
+  watch:
+    apiVersion: v1
+    resource: namespaces
+    nameSelector:
+    # we are interested in amitd namespace only
+    - amitd
+  attachments:
+  - apiVersion: apiextensions.k8s.io/v1beta1
+    resource: customresourcedefinitions
+    nameSelector:
+    # we are interested in storages CRD only
+    - storages.dao.amitd.io
+  hooks:
+    sync:
+      webhook:
+        url: http://jsonnetd.metac/sync-crd
+    finalize:
+      webhook:
+        url: http://jsonnetd.metac/finalize-crd
+---
+---
+---
+kind: Test
+stuff: 1
+test-foo: 2
+---
+`))
+	if err != nil {
+		t.Fatalf("Expected no error got %v", err)
+	}
+	if len(ul) == 0 {
+		t.Fatalf("Expected multiple unstruct instances got %d", len(ul))
+	}
+
+	var mc MetacConfigs
+	mc = append(mc, ul...)
+	gctls, err := mc.ListGenericControllers()
+	if err != nil {
+		t.Fatalf("Expected no error got %v", err)
+	}
+	if len(gctls) != 1 {
+		t.Fatalf("Expected one generic controller config count got %d", len(gctls))
+	}
+	gctl := gctls[0]
+	if gctl.GetName() != "install-un-crd" {
+		t.Fatalf("Expected gctl name 'install-un-crd' got %q", gctl.GetName())
+	}
+	if len(gctl.Spec.Attachments) != 1 {
+		t.Fatalf("Expected one attachment got %d", len(gctl.Spec.Attachments))
+	}
+	if *gctl.Spec.Hooks.Sync.Webhook.URL != "http://jsonnetd.metac/sync-crd" {
+		t.Fatalf(
+			"Expected sync 'http://jsonnetd.metac/sync-crd' got %s",
+			*gctl.Spec.Hooks.Sync.Webhook.URL,
+		)
+	}
+	if *gctl.Spec.Hooks.Finalize.Webhook.URL != "http://jsonnetd.metac/finalize-crd" {
+		t.Fatalf(
+			"Expected sync 'http://jsonnetd.metac/finalize-crd' got %s",
+			*gctl.Spec.Hooks.Finalize.Webhook.URL,
+		)
+	}
+}

--- a/controller/generic/selector.go
+++ b/controller/generic/selector.go
@@ -196,7 +196,7 @@ func (s *Selector) Matches(obj *unstructured.Unstructured) bool {
 }
 
 // makeSelectorKeyFromGK returns a formatted string suitable to be
-// used as a key
+// used as a key of form 'kind.apigroup'
 //
 // The returned key is based on a combination of api group & kind
 func makeSelectorKeyFromGK(apiGroup, kind string) string {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-jsonnet v0.14.0
 	github.com/pkg/errors v0.8.1
 	go.opencensus.io v0.21.0
+	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20191005115622-2e41325d9e4b
 	k8s.io/apiextensions-apiserver v0.0.0-20191008120836-c5dfed5b5134
 	k8s.io/apimachinery v0.0.0-20191006235458-f9f2f3f8ab02

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -142,11 +142,18 @@ func testMain(tests func() int) error {
 	// anything. Instead, we start the Metacontroller server
 	// locally inside the test binary, since that's part of the
 	// code under test.
-	stopServer, err := server.Start(
-		ApiserverConfig(), 500*time.Millisecond, 30*time.Minute, 5,
-	)
+	var mserver = server.Server{
+		Config:            ApiserverConfig(),
+		DiscoveryInterval: 500 * time.Millisecond,
+		InformerRelist:    30 * time.Minute,
+	}
+	crdServer := &server.CRDBasedServer{Server: mserver}
+	stopServer, err := crdServer.Start(5)
+	//stopServer, err := server.Start(
+	//	ApiserverConfig(), 500*time.Millisecond, 30*time.Minute, 5,
+	//)
 	if err != nil {
-		return errors.Wrapf(err, "Can't start metacontroller server")
+		return errors.Wrapf(err, "Can't start crd based metacontroller server")
 	}
 	defer stopServer()
 

--- a/third_party/kubernetes/pointer.go
+++ b/third_party/kubernetes/pointer.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/third_party/kubernetes/yaml.go
+++ b/third_party/kubernetes/yaml.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	goyaml "gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// I do not remember the exact project from where this has been
+// borrowed. The only thing I can remember is, this was from some
+// Kubernetes sig or related project.
+
+const (
+	yamlSeparator = "\n---\n"
+)
+
+// UnstructList mimics a Kubernetes List object which
+// can contain multiple other resources in its Items
+// slice
+type UnstructList struct {
+	// ApiVersion represent the lists ApiVersion
+	//
+	// NOTE:
+	//	This should always be "v1" that marks it as
+	// a stable api and hence hopefully avoids
+	// incompatibilities w.r.t Kubernetes conversions.
+	APIVersion string `yaml:"apiVersion"`
+
+	// Kind represents the lists Kind
+	//
+	// NOTE:
+	//	This should always be set to "List" to hopefully
+	// avoid breaking things from Kubernetes convertions
+	Kind string `yaml:"kind"`
+
+	// Items represents the list of items that this
+	// List holds.
+	//
+	// NOTE:
+	//	This field is important to represent this
+	// List as unstructured.UnstructuredList
+	//
+	// NOTE:
+	//	Convert all items to `map[string]interface{}`
+	// for correct yaml marshalling
+	//
+	// NOTE:
+	//	Each item corresponds to an unstructured instance's
+	// Object field
+	Items []map[string]interface{} `yaml:"items"`
+}
+
+// yamlToJSON converts a byte slice containing yaml into
+// a byte slice containing json
+func yamlToJSON(in []byte) ([]byte, error) {
+	return yaml.ToJSON(in)
+}
+
+// JSONToUnstructured converts a raw json document into an
+// Unstructured object
+func JSONToUnstructured(in []byte) (unstructured.Unstructured, error) {
+	obj := unstructured.Unstructured{}
+	err := obj.UnmarshalJSON(in)
+	if err != nil {
+		return unstructured.Unstructured{}, errors.Wrapf(err, "Failed to unmarshal JSON")
+	}
+	return obj, nil
+}
+
+// YAMLToUnstructured converts either a single yaml document or
+// list of yaml documents into an Unstructured object
+func YAMLToUnstructured(in []byte) (u unstructured.Unstructured, err error) {
+	var data []byte
+	yamlList := splitYAML(in)
+	if len(yamlList) != 1 {
+		// this is a list of raw yaml documents
+		// convert this to a known struct that
+		// understands list of Kubernetes yamls
+		data, err = toList(yamlList)
+		if err != nil {
+			return u,
+				errors.Wrapf(err, "Failed to split yaml docs: Len %d", len(yamlList))
+		}
+	} else {
+		// this is just a single yaml document
+		data = yamlList[0]
+	}
+	json, err := yamlToJSON(data)
+	if err != nil {
+		return u, errors.Wrapf(err, "Failed to convert YAML to JSON")
+	}
+	return JSONToUnstructured(json)
+}
+
+// YAMLToUnstructuredSlice converts a raw yaml document into a
+// slice of pointers to Unstructured objects
+func YAMLToUnstructuredSlice(in []byte) ([]unstructured.Unstructured, error) {
+	u, err := YAMLToUnstructured(in)
+	if err != nil {
+		return nil, err
+	}
+	if u.IsList() {
+		result := []unstructured.Unstructured{}
+		err = u.EachListItem(func(obj runtime.Object) error {
+			o, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				kind := obj.GetObjectKind().GroupVersionKind().Kind
+				return errors.Errorf("Resource %s is not an unstructured type", kind)
+			}
+			result = append(result, *o)
+			return nil
+		})
+		if err != nil {
+			return nil,
+				errors.Wrapf(
+					err,
+					"Failed to convert yaml docs into slice of unstructured instances",
+				)
+		}
+		return result, nil
+	}
+	return []unstructured.Unstructured{u}, nil
+}
+
+// splitYAML will take raw yaml from a file and split yaml
+// documents on the yaml separator `---`, returning a list
+// of documents in the original input
+func splitYAML(in []byte) (out [][]byte) {
+	split := bytes.Split(in, []byte(yamlSeparator))
+	for _, data := range split {
+		if len(data) > 0 {
+			out = append(out, data)
+		}
+	}
+	return
+}
+
+// toList converts a slice of yaml documents into a
+// Kubernetes List kind
+func toList(in [][]byte) ([]byte, error) {
+	items := []map[string]interface{}{}
+	for _, item := range in {
+		data := make(map[string]interface{})
+		err := goyaml.Unmarshal(item, data)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to unmarshal")
+		}
+		items = append(items, data)
+	}
+	return goyaml.Marshal(&UnstructList{
+		APIVersion: "v1",
+		Kind:       "List",
+		Items:      items,
+	})
+}

--- a/third_party/kubernetes/yaml_test.go
+++ b/third_party/kubernetes/yaml_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type mockYmlMap map[string]interface{}
+
+// TestAnyYamlDoc should work. This is basically
+// a test of yaml.NewYAMLOrJSONDecoder only & nothing
+// related to Metac.
+func TestAnyYamlDoc(t *testing.T) {
+	u, err := YAMLToUnstructured([]byte(`
+kind: Test
+stuff: 1
+test-foo: 2
+`))
+	if err != nil {
+		t.Fatalf("Expected no error: Got %s", err.Error())
+	}
+	if u.UnstructuredContent() == nil {
+		t.Fatalf("Expected yaml content: Got none")
+	}
+	stuff, _, _ := unstructured.NestedInt64(u.Object, "stuff")
+	if stuff != 1 {
+		t.Fatalf("Expected 1 Got %d", stuff)
+	}
+	testfoo, _, _ := unstructured.NestedInt64(u.Object, "test-foo")
+	if testfoo != 2 {
+		t.Fatalf("Expected 2 Got %d", testfoo)
+	}
+}
+
+// TestAnyMultiYamlDocs should work. This is basically
+// a test of yaml.NewYAMLOrJSONDecoder only & nothing
+// related to Metac.
+func TestAnyMultiYamlDocs(t *testing.T) {
+	ul, err := YAMLToUnstructuredSlice([]byte(`---
+kind: YourTest
+stuff: 1
+test-foo: 2
+---
+---
+kind: MyTest
+stuff: 2
+test-foo: 3
+---
+`))
+	if err != nil {
+		t.Fatalf("Expected no error: Got %s", err.Error())
+	}
+
+	if len(ul) != 2 {
+		t.Fatalf("Expected yaml count 2: Got %d", len(ul))
+	}
+
+	yaml1, yaml2 := ul[0], ul[1]
+	yml1stuff, _, _ :=
+		unstructured.NestedInt64(yaml1.UnstructuredContent(), "stuff")
+	yml1testfoo, _, _ :=
+		unstructured.NestedInt64(yaml1.UnstructuredContent(), "test-foo")
+	if yml1stuff != 1 || yml1testfoo != 2 {
+		t.Fatalf(
+			"Expected stuff 1 Got %d: Expected test-foo 2 Got %d",
+			yml1stuff, yml1testfoo,
+		)
+	}
+
+	yml2stuff, _, _ :=
+		unstructured.NestedInt64(yaml2.UnstructuredContent(), "stuff")
+	yml2testfoo, _, _ :=
+		unstructured.NestedInt64(yaml2.UnstructuredContent(), "test-foo")
+	if yml2stuff != 2 || yml2testfoo != 3 {
+		t.Fatalf(
+			"Expected stuff 2 Got %d: Expected test-foo 3 Got %d",
+			yml2stuff, yml2testfoo,
+		)
+	}
+}
+
+// TestKubernetesYamlDocToUnstruct should work.
+//
+// NOTE:
+//	Keep a note on the tab vs. spaces while writing below
+// yaml. Stick to spaces.
+func TestKubernetesYamlDocToUnstruct(t *testing.T) {
+	u, err := YAMLToUnstructured([]byte(`---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: genericcontrollers.metac.openebs.io
+spec:
+  group: metac.openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: genericcontrollers
+    singular: genericcontroller
+    kind: GenericController
+    shortNames:
+    - gctl
+---
+`))
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v", err)
+	}
+	if u.GetAPIVersion() != "apiextensions.k8s.io/v1beta1" {
+		t.Fatalf("Expected apiVersion 'apiextensions.k8s.io/v1beta1' Got %q", u.GetAPIVersion())
+	}
+	if u.GetKind() != "CustomResourceDefinition" {
+		t.Fatalf("Expected kind 'CustomResourceDefinition' Got %q", u.GetKind())
+	}
+	if u.GetName() != "genericcontrollers.metac.openebs.io" {
+		t.Fatalf("Expected name 'genericcontrollers.metac.openebs.io' Got %q", u.GetName())
+	}
+	scope, _, _ :=
+		unstructured.NestedString(u.UnstructuredContent(), "spec", "scope")
+	if scope != "Namespaced" {
+		t.Fatalf("Expected scope 'Namespaced' Got %q", scope)
+	}
+	shortNames, _, _ :=
+		unstructured.NestedStringSlice(u.UnstructuredContent(), "spec", "names", "shortNames")
+	if len(shortNames) != 1 || strings.Join(shortNames, "") != "gctl" {
+		t.Fatalf("Expected shortnames 'gctl' Got %v", shortNames)
+	}
+}
+
+// TestKubernetesYamlDocsToUnstructs should work.
+//
+// NOTE:
+//	Keep a note on the tab vs. spaces while writing below
+// yaml. Stick to spaces.
+func TestKubernetesYamlDocsToUnstructs(t *testing.T) {
+	ul, err := YAMLToUnstructuredSlice([]byte(`---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: genericcontrollers.metac.openebs.io
+spec:
+  group: metac.openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: genericcontrollers
+    singular: genericcontroller
+    kind: GenericController
+    shortNames:
+    - gctl
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: controllerrevisions.metac.openebs.io
+spec:
+  group: metac.openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: controllerrevisions
+    singular: controllerrevision
+    kind: ControllerRevision
+---
+`))
+
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v", err)
+	}
+
+	if len(ul) != 2 {
+		t.Fatalf("Expected yaml count 2: Got %d", len(ul))
+	}
+
+	yaml1, yaml2 := ul[0], ul[1]
+	if yaml1.GetName() != "genericcontrollers.metac.openebs.io" {
+		t.Fatalf("Expected name 'genericcontrollers.metac.openebs.io' got %q", yaml1.GetName())
+	}
+	if yaml2.GetName() != "controllerrevisions.metac.openebs.io" {
+		t.Fatalf("Expected name 'controllerrevisions.metac.openebs.io' got %q", yaml2.GetName())
+	}
+}
+
+// TestMetaControllerDocsToUnstructs should work.
+//
+// NOTE:
+//	Keep a note on the tab vs. spaces while writing below
+// yaml. Stick to spaces.
+func TestMetaControllerDocsToUnstructs(t *testing.T) {
+	ul, err := YAMLToUnstructuredSlice([]byte(`---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: install-un-crd
+spec:
+  watch:
+    apiVersion: v1
+    resource: namespaces
+    nameSelector:
+    # we are interested in amitd namespace only
+    - amitd
+  attachments:
+  - apiVersion: apiextensions.k8s.io/v1beta1
+    resource: customresourcedefinitions
+    nameSelector:
+    # we are interested in storages CRD only
+    - storages.dao.amitd.io
+  hooks:
+    sync:
+      webhook:
+        url: http://jsonnetd.metac/sync-crd
+    finalize:
+      webhook:
+        url: http://jsonnetd.metac/finalize-crd
+---
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: daemonjob-controller
+spec:
+  generateSelector: true
+  parentResource:
+    apiVersion: ctl.example.com/v1
+    resource: daemonjobs
+  childResources:
+  - apiVersion: apps/v1
+    resource: daemonsets
+  hooks:
+    sync:
+      webhook:
+        url: http://daemonjob-controller.metacontroller/sync
+---
+`))
+
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v", err)
+	}
+
+	if len(ul) != 2 {
+		t.Fatalf("Expected yaml count 2: Got %d", len(ul))
+	}
+
+	yaml1, yaml2 := ul[0], ul[1]
+	if yaml1.GetKind() != "GenericController" {
+		t.Fatalf("Expected kind 'GenericController' got %q", yaml1.GetKind())
+	}
+	if yaml1.GetName() != "install-un-crd" {
+		t.Fatalf("Expected name 'install-un-crd' got %q", yaml1.GetName())
+	}
+
+	if yaml2.GetKind() != "CompositeController" {
+		t.Fatalf("Expected kind 'CompositeController' got %q", yaml2.GetKind())
+	}
+	if yaml2.GetName() != "daemonjob-controller" {
+		t.Fatalf("Expected name 'daemonjob-controller' got %q", yaml2.GetName())
+	}
+}


### PR DESCRIPTION
This commit is first of the series of commits that will enable metac to be run from **_local config_** in addition to the current way of running it by watching Kubernetes based custom resources i.e.
via _CompositeController_, _DecoratorController_ & _GenericController_ resource kinds.

This commit focuses on enabling running metac from local config for generic controller only. Once this feature graduates from experimental to stable, it will be added to other meta controllers.

Some of the typical usecases that are fit for this local mode of running metac include: _Install_, _Un-Install_, _Upgrade_, _Conformance Tests_, etc. One would typically like to avoid depending on additional CRDs to get these requirements done. In such cases, one hopes to deploy a container that makes use of metac binary & expects it to solve above mentioned use-cases.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>