### PR TITLE
add skipReconcile to GenericController hook response

### DIFF
--- a/TODO
+++ b/TODO
@@ -70,15 +70,17 @@
     - Unit Test 3-way merge
     - Unit Test 2-way merge
     - Check if 3-way can be converted to 2-way merge on some condition
-- Skip Reconcile support - 2
+- Skip Reconcile support - 2 - DONE
+- Skip Reconcile example - ?
+- Skip Reconcile integration tests - ?
 - Advanced Selector support - 6
     - study existing implementation; push more code comments
     - study existing unit tests; push more code comments
     - look again at the names of key, operator, etc;
     - implement the required stuff
-- Local config based execution - 1
-    - Read existing changes; push more code comments
-    - Send PR
+- Local config based execution - 1 - DONE
+    - Read existing changes; push more code comments - DONE
+    - Send PR - DONE
 - Local config based examples - 7
 - Local config based integration tests - 8
 - Namespace controlled execution - 3

--- a/controller/generic/hooks.go
+++ b/controller/generic/hooks.go
@@ -63,6 +63,11 @@ type SyncHookResponse struct {
 	// the specified interval
 	ResyncAfterSeconds float64 `json:"resyncAfterSeconds"`
 
+	// When true skips reconciliation of attachments
+	// This is expected to be set to a boolean value based
+	// on runtime conditions while executing the hook logic
+	SkipReconcile bool `json:"skipReconcile"`
+
 	// Finalized should only be used by the finalize hook. If
 	// true then this response will be applied by metacontroller.
 	Finalized bool `json:"finalized"`


### PR DESCRIPTION
SkipReconcile is a flag that skips reconciliation of GenericController's attachments. This tunable is only supported for GenericController.

SkipReconcile looks similar to GenericController's spec.ReadOnly. However, both of them serve different purposes. SkipReconcile is dynamic and is set by the sync hook implementation. However ReadOnly is a static option that is set in GenericController's spec.

In other words, one expects SkipReconcile to vary from true to false or vice versa depending on runtime conditions. On the other hand, ReadOnly is expected to be set to true or false for the entire
lifecycle of the controller.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>