### PR TITLE
separate selector logic for watch & attachments of gctl

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,17 +1,7 @@
 ### TODO:
 - Test metac with changes to rbac 
-- Make all examples to work & then make it better
 - Add integration tests w.r.t GenericController:
-    - check if finalizer works
-    - check if attachments not created by gctl are not updated
-    - check if attachments not created by gctl are not deleted
-    - check if ReadOnly works
-    - check if UpdateAny works
-    - check if DeleteAny works
     - check if same watch can update an attachment via multiple gctl specs
-    - check for 2-way merge as well as 3-way merge
-        - default to 2-way merge if only finalize hook is present
-        - default to 3-way merge if both sync & finalize hooks are present
     - send specific parts of attachments:
         - send - []string{Name, MetaData, Labels, Annotations, Spec, Status} 
         - default sends everything
@@ -46,16 +36,9 @@
       - CustomResource, or # current mode
       - Config # default mode
   - make cctl, dctl & gctl work from config files vs. current way that depends on CRDs
-- Explore the one binary sidecars
-    - jsonnetd service + hooks as a docker image
 - Use latest stable Kubernetes version & etcd for integration testing
 - restructure examples to enable community
 - code to use klog
-- test/unittest
-- find bugs & fix
-- Make metacontroller watch resources from specific namespace if required
-- Should Metac support UDS?
-    - https://eli.thegreenplace.net/2019/unix-domain-sockets-in-go/
 - >>enisoc 2:08 AM
     if the new client-go dynamic informer does everything metacontroller needs 
     (e.g. start/stop dynamically without process restart), it would be great to
@@ -66,28 +49,22 @@
 
 
 ### Updated TODO List With Priority
-- Apply via Update support - 5
-    - Unit Test 3-way merge
-    - Unit Test 2-way merge
-    - Check if 3-way can be converted to 2-way merge on some condition
-- Skip Reconcile support - 2 - DONE
+- Skip Reconcile support - DONE
 - Skip Reconcile example - ?
-- Skip Reconcile integration tests - ?
-- Advanced Selector support - 6
+- Advanced Selector support - 1
     - study existing implementation; push more code comments
     - study existing unit tests; push more code comments
     - look again at the names of key, operator, etc;
     - implement the required stuff
-- Local config based execution - 1 - DONE
-    - Read existing changes; push more code comments - DONE
-    - Send PR - DONE
-- Local config based examples - 7
-- Local config based integration tests - 8
-- Namespace controlled execution - 3
-- Allowed-namespaces based flag - 4
-- Send specific parts of attachments - 9
+- Local config based examples - 3
+- Local config based integration tests - 2
+    - Split manifests
+    - Design a separate suite_test.go for local config based tests
+- Send specific parts of attachments - ?
     - e.g. namespace & name, metadata only, status only, metadata + spec, labels only, annotations only, 
-    - examples - 10
-    - integration tests - 11
+    - examples - ?
+    - integration tests - ?
 - Simplify Integration Tests - ?
     - refer to apiserver-extensions project
+- Inline Hook Calls - 4
+- Inline Hook Call Integration Tests - 5

--- a/controller/common/manage_children.go
+++ b/controller/common/manage_children.go
@@ -100,12 +100,11 @@ func (a *Apply) Merge(
 	return a.merge(orig, update)
 }
 
-// merge applies the update against the original object in the
-// style of kubectl apply
+// merge applies the update against the original object
+// in the style of kubectl apply
 //
-// TODO(@amitkumardas):
-// ApplyMerge along with reflect.DeepEqual may be used to build
-// assert logic based on observed yaml vs. desired yaml
+// NOTE:
+//	This should be invoked from the public Merge method
 func (a *Apply) merge(
 	orig, update *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -67,7 +67,7 @@ type parentController struct {
 	updateStrategy updateStrategyMap
 	childInformers common.ResourceInformerRegistryByVR
 
-	finalizer *finalizer.Manager
+	finalizer *finalizer.Finalizer
 }
 
 func newParentController(
@@ -150,7 +150,7 @@ func newParentController(
 			workqueue.DefaultControllerRateLimiter(),
 			"CompositeController-"+api.Name,
 		),
-		finalizer: &finalizer.Manager{
+		finalizer: &finalizer.Finalizer{
 			Name:    "metac.openebs.io/compositecontroller-" + api.Name,
 			Enabled: api.Spec.Hooks.Finalize != nil,
 		},

--- a/controller/decorator/controller.go
+++ b/controller/decorator/controller.go
@@ -88,7 +88,7 @@ type decoratorController struct {
 
 	// instance that deals with this controller's finalizer
 	// if any
-	finalizer *finalizer.Manager
+	finalizer *finalizer.Finalizer
 }
 
 // newDecoratorController returns a new instance of decorator
@@ -115,7 +115,7 @@ func newDecoratorController(
 			"DecoratorController-"+schema.Name,
 		),
 
-		finalizer: &finalizer.Manager{
+		finalizer: &finalizer.Finalizer{
 			// finalizer manager is entrusted with this finalier name
 			Name: "metac.openebs.io/decoratorcontroller-" + schema.Name,
 			// gets enabled if Finalize property is set

--- a/controller/doc.go
+++ b/controller/doc.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller holds the business logic for this project.
-// Metac is all about providing a toolkit to develop Kubernetes
-// controllers.
+// Package controller holds the business logic for all the meta
+// controllers implemented by metac. The meta controllers that are
+// currently supported are:
+//
+// 1/ Composite Controller
+// 2/ Decorator Controller
+// 3/ Generic Controller
 package controller

--- a/controller/generic/updatestrategy.go
+++ b/controller/generic/updatestrategy.go
@@ -26,7 +26,7 @@ import (
 	dynamicdiscovery "openebs.io/metac/dynamic/discovery"
 )
 
-type attachmentUpdateStrategyManager struct {
+type attachmentUpdateStrategyFinder struct {
 	// strategies holds update strategies of attachments
 	// corresponding to GenericController
 	strategies map[string]*v1alpha1.GenericControllerAttachmentUpdateStrategy
@@ -37,30 +37,8 @@ type attachmentUpdateStrategyManager struct {
 }
 
 // String implements Stringer interface
-func (mgr attachmentUpdateStrategyManager) String() string {
+func (mgr attachmentUpdateStrategyFinder) String() string {
 	return "attachmentUpdateStrategyManager"
-}
-
-// GetByGKOrDefault returns the attachment update strategy based on
-// the given api group & kind
-func (mgr attachmentUpdateStrategyManager) GetByGKOrDefault(
-	apiGroup, kind string,
-) v1alpha1.ChildUpdateMethod {
-
-	strategy := mgr.getByGK(apiGroup, kind)
-	if strategy == nil || strategy.Method == "" {
-		return mgr.defaultMethod
-	}
-	return strategy.Method
-}
-
-// get returns the controller's attachment's upgrade strategy
-// based on the given api group & kind
-func (mgr attachmentUpdateStrategyManager) getByGK(
-	apiGroup, kind string,
-) *v1alpha1.GenericControllerAttachmentUpdateStrategy {
-
-	return mgr.strategies[makeUpdateStrategyKeyFromGK(apiGroup, kind)]
 }
 
 // makeUpdateStrategyKeyFromGK builds a key to be used in
@@ -70,14 +48,14 @@ func makeUpdateStrategyKeyFromGK(apiGroup, kind string) string {
 	return fmt.Sprintf("%s.%s", kind, apiGroup)
 }
 
-// newAttachmentUpdateStrategyManager returns a new instance of
+// newAttachmentUpdateStrategyFinder returns a new instance of
 // attachmentUpdateStrategyManager.
-func newAttachmentUpdateStrategyManager(
+func newAttachmentUpdateStrategyFinder(
 	resourceMgr *dynamicdiscovery.APIResourceManager,
 	attachments []v1alpha1.GenericControllerAttachment,
-) (*attachmentUpdateStrategyManager, error) {
+) (*attachmentUpdateStrategyFinder, error) {
 
-	mgr := &attachmentUpdateStrategyManager{
+	mgr := &attachmentUpdateStrategyFinder{
 		strategies: make(
 			map[string]*v1alpha1.GenericControllerAttachmentUpdateStrategy,
 		),
@@ -110,4 +88,26 @@ func newAttachmentUpdateStrategyManager(
 		}
 	}
 	return mgr, nil
+}
+
+// getStrategyByGK returns the attachment upgrade strategy
+// based on the given api group & kind
+func (mgr attachmentUpdateStrategyFinder) getStrategyByGK(
+	apiGroup, kind string,
+) *v1alpha1.GenericControllerAttachmentUpdateStrategy {
+
+	return mgr.strategies[makeUpdateStrategyKeyFromGK(apiGroup, kind)]
+}
+
+// GetStrategyByGKOrDefault returns the attachment update strategy
+// based on the given api group & kind
+func (mgr attachmentUpdateStrategyFinder) GetStrategyByGKOrDefault(
+	apiGroup, kind string,
+) v1alpha1.ChildUpdateMethod {
+
+	strategy := mgr.getStrategyByGK(apiGroup, kind)
+	if strategy == nil || strategy.Method == "" {
+		return mgr.defaultMethod
+	}
+	return strategy.Method
 }

--- a/dynamic/apply/apply_test.go
+++ b/dynamic/apply/apply_test.go
@@ -37,30 +37,46 @@ func TestMerge(t *testing.T) {
 			want:        `{}`,
 		},
 		{
-			name: "scalars",
-			observed: `{
-				"keep": "other",
-				"remove": "other",
-				"replace": "other"
-			}`,
-			lastApplied: `{"remove": "old", "replace": "old"}`,
-			desired:     `{"replace": "new", "add": "new" }`,
-			want: `{
-				"replace": "new",
-				"add": "new",
-				"keep": "other"
-			}`,
+			name:        "scalars",
+			observed:    `{"a": "old", "b": "old", "c": "old"}`,
+			lastApplied: `{"b": "old", "c": "old"}`,
+			desired:     `{"c": "new", "d": "new" }`,
+			want:        `{"c": "new", "d": "new", "a": "old"}`,
 		},
 		{
-			name: "nested object",
-			observed: `{
-				"update": {"keep": "other", "remove": "other"}
-			}`,
-			lastApplied: `{"update": {"remove": "old", "replace": "old"}}`,
-			desired:     `{"update": {"replace": "new", "add": "new"}}`,
-			want: `{
-				"update": {"replace": "new", "add": "new", "keep": "other"}
-			}`,
+			name:        "scalars minus last applied",
+			observed:    `{"a": "old", "b": "old", "c": "old"}`,
+			lastApplied: `{}`,
+			desired:     `{"a": "new", "d": "new" }`,
+			want:        `{"a": "new", "d": "new", "b": "old", "c": "old"}`,
+		},
+		{
+			name:        "scalars with last applied equals desired",
+			observed:    `{"a": "old", "b": "old", "c": "old"}`,
+			lastApplied: `{"a": "new", "d": "new"}`,
+			desired:     `{"a": "new", "d": "new"}`,
+			want:        `{"a": "new", "b": "old", "c": "old", "d": "new"}`,
+		},
+		{
+			name:        "nested object",
+			observed:    `{"hey": {"a": "old", "b": "old"}}`,
+			lastApplied: `{"hey": {"b": "old", "a": "old"}}`,
+			desired:     `{"hey": {"a": "new", "c": "new"}}`,
+			want:        `{"hey": {"a": "new", "c": "new"}}`,
+		},
+		{
+			name:        "nested object minus last applied",
+			observed:    `{"hey": {"a": "old", "b": "old"}}`,
+			lastApplied: `{}`,
+			desired:     `{"hey": {"a": "new", "c": "new"}}`,
+			want:        `{"hey": {"a": "new", "b": "old", "c": "new"}}`,
+		},
+		{
+			name:        "nested object with last applied equals desired",
+			observed:    `{"hey": {"a": "old", "b": "old"}}`,
+			lastApplied: `{"hey": {"a": "new", "c": "new"}}`,
+			desired:     `{"hey": {"a": "new", "c": "new"}}`,
+			want:        `{"hey": {"a": "new", "b": "old", "c": "new"}}`,
 		},
 		{
 			name:        "replace list",
@@ -70,33 +86,88 @@ func TestMerge(t *testing.T) {
 			want:        `{"list": [7,8,9,{"b":false}]}`,
 		},
 		{
+			name:        "replace list minus last applied",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{}`,
+			desired:     `{"list": [7,8,9,{"b":false}]}`,
+			want:        `{"list": [7,8,9,{"b":false}]}`,
+		},
+		{
+			name:        "replace list with last applied equals desired",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{"list": [7,8,9,{"b":false}]}`,
+			desired:     `{"list": [7,8,9,{"b":false}]}`,
+			want:        `{"list": [7,8,9,{"b":false}]}`,
+		},
+		{
+			name:        "remove list minus last applied",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{}`,
+			desired:     `{"list": []}`,
+			want:        `{"list": []}`,
+		},
+		{
+			name:        "remove list with last applied",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{"list": [7,8,9,{"b":false}]}`,
+			desired:     `{"list": []}`,
+			want:        `{"list": []}`,
+		},
+		{
+			name:        "remove object with last applied minus desired",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{"list": [7,8,9,{"b":false}]}`,
+			desired:     `{}`,
+			want:        `{}`,
+		},
+		{
+			name:        "keep list minus last applied minus desired",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{}`,
+			desired:     `{}`,
+			want:        `{"list": [1,2,3,{"a":true}]}`,
+		},
+		{
+			name:        "remove specific items from list",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{"list": [2,{"a":true}]}`,
+			desired:     `{"list": [3,{"a":true}]}`,
+			want:        `{"list": [3,{"a":true}]}`,
+		},
+		{
+			name:        "remove specific items from list minus last applied",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{}`,
+			desired:     `{"list": [3,{"a":true}]}`,
+			want:        `{"list": [3,{"a":true}]}`,
+		},
+		{
+			name:        "remove specific items from list with empty last applied",
+			observed:    `{"list": [1,2,3,{"a":true}]}`,
+			lastApplied: `{"list": []}`,
+			desired:     `{"list": [3,{"a":true}]}`,
+			want:        `{"list": [3,{"a":true}]}`,
+		},
+		{
 			name: "merge list-map",
 			observed: `{
-        "listMap": [
-          {"name": "keep", "value": "other"},
-          {"name": "remove", "value": "other"},
-          {"name": "merge", "nested": {"keep": "other"}}
-        ],
-				"ports1": [
-					{"port": 80, "keep": "other"}
+				"listMap": [
+					{"name": "keep", "value": "other"},
+					{"name": "remove", "value": "other"},
+					{"name": "merge", "nested": {"keep": "other"}}
 				],
-				"ports2": [
-					{"containerPort": 80, "keep": "other"}
-				]
-      }`,
+				"ports1": [{"port": 80, "keep": "other"}],
+				"ports2": [{"containerPort": 80, "keep": "other"}]
+      		}`,
 			lastApplied: `{
-        "listMap": [
-          {"name": "remove", "value": "old"}
-        ],
-				"ports1": [
-					{"port": 80, "remove": "old"}
-				]
-      }`,
+				"listMap": [{"name": "remove", "value": "old"}],
+				"ports1": [{"port": 80, "remove": "old"}]
+		    }`,
 			desired: `{
-        "listMap": [
-          {"name": "add", "value": "new"},
-          {"name": "merge", "nested": {"add": "new"}}
-        ],
+				"listMap": [
+					{"name": "add", "value": "new"},
+					{"name": "merge", "nested": {"add": "new"}}
+				],
 				"ports1": [
 					{"port": 80, "add": "new"},
 					{"port": 90}
@@ -105,13 +176,13 @@ func TestMerge(t *testing.T) {
 					{"containerPort": 80},
 					{"containerPort": 90}
 				]
-      }`,
+      		}`,
 			want: `{
-        "listMap": [
-          {"name": "keep", "value": "other"},
-          {"name": "merge", "nested": {"keep": "other", "add": "new"}},
-          {"name": "add", "value": "new"}
-        ],
+				"listMap": [
+					{"name": "keep", "value": "other"},
+					{"name": "merge", "nested": {"keep": "other", "add": "new"}},
+					{"name": "add", "value": "new"}
+				],
 				"ports1": [
 					{"port": 80, "keep": "other", "add": "new"},
 					{"port": 90}
@@ -120,34 +191,32 @@ func TestMerge(t *testing.T) {
 					{"containerPort": 80, "keep": "other"},
 					{"containerPort": 90}
 				]
-      }`,
+      		}`,
 		},
 		{
 			name: "replace list of objects that's not a list-map",
 			observed: `{
-        "notListMap": [
-          {"name": "keep", "value": "other"},
-          {"notName": "remove", "value": "other"},
-          {"name": "merge", "nested": {"keep": "other"}}
-        ]
-      }`,
+				"notListMap": [
+					{"name": "keep", "value": "other"},
+					{"notName": "remove", "value": "other"},
+					{"name": "merge", "nested": {"keep": "other"}}
+				]
+			}`,
 			lastApplied: `{
-        "notListMap": [
-          {"name": "remove", "value": "old"}
-        ]
-      }`,
+				"notListMap": [{"name": "remove", "value": "old"}]
+      		}`,
 			desired: `{
-        "notListMap": [
-          {"name": "add", "value": "new"},
-          {"name": "merge", "nested": {"add": "new"}}
-        ]
-      }`,
+				"notListMap": [
+					{"name": "add", "value": "new"},
+					{"name": "merge", "nested": {"add": "new"}}
+				]
+      		}`,
 			want: `{
-        "notListMap": [
-          {"name": "add", "value": "new"},
-          {"name": "merge", "nested": {"add": "new"}}
-        ]
-      }`,
+				"notListMap": [
+					{"name": "add", "value": "new"},
+					{"name": "merge", "nested": {"add": "new"}}
+				]
+			}`,
 		},
 	}
 

--- a/dynamic/object/metadata.go
+++ b/dynamic/object/metadata.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 Google Inc.
+Copyright 2019 The MayaData Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,4 +50,29 @@ func RemoveFinalizer(obj metav1.Object, name string) {
 		}
 	}
 	// We never found it, so it's already gone and there's nothing to do.
+}
+
+// HasAnnotation returns true if given object has the provided
+// annotation
+func HasAnnotation(obj metav1.Object, key, value string) bool {
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		return false
+	}
+	return anns[key] == value
+}
+
+// AddAnnotation adds the given annotation to obj, if it
+// isn't already present.
+func AddAnnotation(obj metav1.Object, key, value string) {
+	if HasAnnotation(obj, key, value) {
+		// It's already present, so there's nothing to do.
+		return
+	}
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		anns = make(map[string]string)
+	}
+	anns[key] = value
+	obj.SetAnnotations(anns)
 }

--- a/test/integration/framework/fixture.go
+++ b/test/integration/framework/fixture.go
@@ -36,7 +36,7 @@ const (
 	// testing involves some amount of wait & retry i.e. polling
 	// these variables are tunables used during polling
 	defaultWaitTimeout  = 60 * time.Second
-	defaultWaitInterval = 200 * time.Millisecond
+	defaultWaitInterval = 500 * time.Millisecond
 )
 
 // Fixture is the base structure that various test cases will make use

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -149,9 +149,6 @@ func testMain(tests func() int) error {
 	}
 	crdServer := &server.CRDBasedServer{Server: mserver}
 	stopServer, err := crdServer.Start(5)
-	//stopServer, err := server.Start(
-	//	ApiserverConfig(), 500*time.Millisecond, 30*time.Minute, 5,
-	//)
 	if err != nil {
 		return errors.Wrapf(err, "Can't start crd based metacontroller server")
 	}


### PR DESCRIPTION
This commit has following changes:
- Implement separate selectors for watch & attachments. This helps in having a resource kind be available in watch as well as attachment but differ by their selector rule.
- Fixes the error when gctl has only Finalize hook set
- Adds new unit tests w.r.t apply logic
- Adds new integration tests w.r.t stuck namespace deletion
- This commit has better log messages, improved code level comments

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>