### PR TITLE
[local] add logs to local config based metac run

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,8 @@ func New(path string) *Config {
 // Load loads all metac config files & converts them
 // to unstructured instances
 func (c *Config) Load() (MetacConfigs, error) {
+	glog.V(4).Infof("Will load config from path %s", c.Path)
+
 	files, readerr := ioutil.ReadDir(c.Path)
 	if readerr != nil {
 		return nil, readerr
@@ -78,6 +80,8 @@ func (c *Config) Load() (MetacConfigs, error) {
 
 	// there can be multiple config files
 	for _, file := range files {
+		glog.V(4).Infof("Will load config file %s", file.Name())
+
 		f, openerr := os.Open(file.Name())
 		if openerr != nil {
 			glog.Errorf("Failed to open metac config file %s: %v", file.Name(), openerr)
@@ -107,7 +111,11 @@ func (c *Config) Load() (MetacConfigs, error) {
 			loaderr = errors.Wrapf(loaderr, "Failed to load metac config %s", file.Name())
 			return nil, loaderr
 		}
+
+		glog.V(4).Infof("Config file %s loaded successfully", file.Name())
 		out = append(out, ul...)
 	}
+
+	glog.V(4).Infof("Config file(s) loaded successfully from path %s", c.Path)
 	return out, nil
 }

--- a/examples/gctl/set-status-on-cr/Dockerfile
+++ b/examples/gctl/set-status-on-cr/Dockerfile
@@ -27,5 +27,5 @@ RUN apt-get update && \
   apt-get install --no-install-recommends -y ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-COPY config.yaml /etc/config/metac/
+COPY config.yaml /etc/config/metac/config.yaml
 COPY --from=builder /go/bin/set-status-on-cr /usr/bin/set-status-on-cr

--- a/examples/gctl/set-status-on-cr/README.md
+++ b/examples/gctl/set-status-on-cr/README.md
@@ -11,6 +11,7 @@ is supposed to set status of a custom resource of kind `CoolNerd`.
 
 ```sh
 kubectl apply -f ns_and_crd.yaml
+kubectl create configmap set-status-on-cr --from-file=config.yaml
 kubectl apply -f operator.yaml
 
 # verify if above was installed properly

--- a/examples/gctl/set-status-on-cr/config.yaml
+++ b/examples/gctl/set-status-on-cr/config.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
@@ -11,4 +10,3 @@ spec:
     sync:
       inline:
         funcName: sync/cool-nerd
----

--- a/examples/gctl/set-status-on-cr/operator.yaml
+++ b/examples/gctl/set-status-on-cr/operator.yaml
@@ -23,4 +23,13 @@ spec:
         - --run-as-local
         - -v=4
         - --discovery-interval=20s
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config/metac/config.yaml
+          subPath: config.yaml
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: set-status-on-cr
 ---


### PR DESCRIPTION
This commit adds some logs/debug information while loading the local configs used to start and run generic meta controller.

In addition, this has few changes to examples that make use of inline hook, local config & generic controller.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>