### PR TITLE
[fix] running metac from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,9 @@ integration-test-gctl: generated_files integration-dependencies
 	@PATH="$(PWD)/hack/bin:$(PATH)" \
 	go test ./test/integration/generic/... -v -timeout 5m \
 	-args --logtostderr -v=1
+
+.PHONY: integration-test-local-gctl
+integration-test-local-gctl: generated_files integration-dependencies
+	@PATH="$(PWD)/hack/bin:$(PATH)" \
+	go test ./test/integration/genericlocal/... -v -timeout 5m \
+	-args --logtostderr -v=1

--- a/apis/metacontroller/v1alpha1/types_generic.go
+++ b/apis/metacontroller/v1alpha1/types_generic.go
@@ -273,5 +273,8 @@ func (gc GenericController) Key() string {
 // GenericControllerKey returns key formatted type for the
 // given namespace & name values
 func GenericControllerKey(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
 	return namespace + "/" + name
 }

--- a/controller/generic/controller.go
+++ b/controller/generic/controller.go
@@ -604,7 +604,7 @@ func (mgr *watchController) syncWatchObj(watch *unstructured.Unstructured) error
 	statusChanged := !reflect.DeepEqual(finalWatchStatus, syncResult.Status)
 
 	glog.V(4).Infof(
-		"%s: Watch %s changes: Labels change %t: Anns change %t: Status change %t",
+		"%s: Watch %s changes: Labels change? %t: Anns change? %t: Status change? %t",
 		mgr, common.DescObjectAsKey(watch), labelsChanged, annotationsChanged, statusChanged,
 	)
 
@@ -621,7 +621,7 @@ func (mgr *watchController) syncWatchObj(watch *unstructured.Unstructured) error
 
 		hasSubResourceStatus := watchClient.HasSubresource("status")
 		glog.V(4).Infof(
-			"%s: Watch %s: Client has status as sub resource %t",
+			"%s: Watch %s: Client has status as sub resource? %t",
 			mgr, common.DescObjectAsKey(watch), hasSubResourceStatus,
 		)
 

--- a/examples/gctl/set-status-on-cr/main.go
+++ b/examples/gctl/set-status-on-cr/main.go
@@ -5,6 +5,19 @@ import (
 	"openebs.io/metac/start"
 )
 
+// sync implements the idempotent logic to get to the desired
+// state
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of reconcile
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of reconcile request.
+//
+// NOTE:
+//	SyncHookRequest has the resource that is under watch, whereas
+// Both SyncHookRequest & SyncHookResponse have the resources that
+// form the desired state w.r.t the watched resource. These
+// resources are known as attachments.
 func sync(req *generic.SyncHookRequest, resp *generic.SyncHookResponse) error {
 	if resp == nil {
 		resp = &generic.SyncHookResponse{}

--- a/start/start.go
+++ b/start/start.go
@@ -120,8 +120,8 @@ func Start() {
 	// start metac either as config based or CRD based
 	if *runAsLocal {
 		configServer := &server.ConfigBasedServer{
-			Server:          mserver,
-			MetacConfigPath: *metacConfigPath,
+			Server:     mserver,
+			ConfigPath: *metacConfigPath,
 		}
 		stopServer, err = configServer.Start(*workerCount)
 	} else {

--- a/test/integration/composite/composite_test.go
+++ b/test/integration/composite/composite_test.go
@@ -39,7 +39,7 @@ import (
 // framework.TestMain provides setup & teardown features required for
 // all the individual testcases to run.
 func TestMain(m *testing.M) {
-	framework.TestMain(m.Run)
+	framework.TestWithCRDMetac(m.Run)
 }
 
 // TestSyncWebhook tests that the sync webhook triggers and passes the

--- a/test/integration/decorator/decorator_test.go
+++ b/test/integration/decorator/decorator_test.go
@@ -36,7 +36,7 @@ import (
 // framework.TestMain provides setup & teardown features required for
 // all the individual testcases to run.
 func TestMain(m *testing.M) {
-	framework.TestMain(m.Run)
+	framework.TestWithCRDMetac(m.Run)
 }
 
 // TestSyncWebhook tests that the sync webhook triggers and passes the

--- a/test/integration/framework/crd.go
+++ b/test/integration/framework/crd.go
@@ -146,7 +146,10 @@ func (f *Fixture) SetupNamespaceCRDAndItsCR(
 	*dynamicclientset.ResourceClient,
 	*unstructured.Unstructured,
 ) {
+	// set up custom resource definition
 	crd, resClient := f.SetupCRD(kind, v1beta1.NamespaceScoped)
+
+	// set up corresponding custom resource
 	obj := BuildUnstructObjFromCRD(crd, name)
 	for _, o := range opts {
 		o(obj)

--- a/test/integration/generic/set_status_on_cr_test.go
+++ b/test/integration/generic/set_status_on_cr_test.go
@@ -32,10 +32,10 @@ import (
 	k8s "openebs.io/metac/third_party/kubernetes"
 )
 
-// TestWatchStatus will verify if GenericController can be
+// TestSetStatusOnCR will verify if GenericController can be
 // used to implement setting of status against the watched
 // resource
-func TestWatchStatus(t *testing.T) {
+func TestSetStatusOnCR(t *testing.T) {
 	// namespace to setup GenericController
 	ctlNSNamePrefix := "gctl-test"
 

--- a/test/integration/genericlocal/set_status_on_cr_test.go
+++ b/test/integration/genericlocal/set_status_on_cr_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericlocal
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+	"openebs.io/metac/controller/generic"
+	"openebs.io/metac/test/integration/framework"
+	k8s "openebs.io/metac/third_party/kubernetes"
+)
+
+// TestLocalSetStatusOnCR will verify if GenericController can be
+// used to implement setting of status against the watched
+// resource
+func TestLocalSetStatusOnCR(t *testing.T) {
+
+	// name of the GenericController
+	ctlName := "set-status-on-cr-localgctrl"
+
+	// name of the target namespace
+	targetNamespaceName := "my-watch-cr"
+
+	// name of the target resource(s) that are created
+	// and are expected to get deleted upon deletion
+	// of target namespace
+	targetResName := "my-cr"
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	// ------------------------------------------------------------
+	// Define the "reconcile logic" for sync i.e. create/update event
+	// ------------------------------------------------------------
+	//
+	// NOTE:
+	// 	This makes use of inline function as hook
+	sHook := func(req *generic.SyncHookRequest, resp *generic.SyncHookResponse) error {
+		if req == nil || req.Watch == nil {
+			t.Logf("Request does not have watch")
+			return nil
+		}
+
+		t.Logf("Request has watch: %s", req.Watch.GetName())
+		if resp == nil {
+			resp = &generic.SyncHookResponse{}
+		}
+		resp.Status = map[string]interface{}{
+			"phase": "Active",
+			"conditions": []string{
+				"GenericController",
+				"InlineHookCall",
+				"RunFromLocalConfig",
+			},
+		}
+		resp.SkipReconcile = true
+
+		t.Logf("Sending response status %v", resp.Status)
+		return nil
+	}
+
+	// Add this sync hook implementation to inline hook registry
+	var testWatchStatusFuncName = "test/gctl-local-set-status-on-cr"
+	generic.AddToInlineRegistry(testWatchStatusFuncName, sHook)
+
+	// ---------------------------------------------------------
+	// Define & Apply a GenericController i.e. a Meta Controller
+	// ---------------------------------------------------------
+
+	// This is one of the meta controller that is defined as
+	// a Kubernetes custom resource. It listens to the resource
+	// specified in the watch field and acts against the resources
+	// specified in the attachments field.
+	gctlConfig := f.CreateGenericControllerAsMetacConfig(
+		ctlName,
+
+		// set sync hook
+		generic.WithInlinehookSyncFunc(k8s.StringPtr(testWatchStatusFuncName)),
+
+		// We want LocalNerd resource as our watched resource
+		generic.WithWatch(
+			&v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "test.metac.openebs.io/v1",
+					Resource:   "localnerds",
+				},
+				// We are interested only for our custom resource
+				NameSelector: []string{targetResName},
+			},
+		),
+	)
+
+	// start metac that uses above GenericController instance as a config
+	stopMetac := f.StartMetacFromGenericControllerConfig(func() ([]*v1alpha1.GenericController, error) {
+		return []*v1alpha1.GenericController{gctlConfig}, nil
+	})
+	defer stopMetac()
+
+	// ---------------------------------------------------
+	// Create the target namespace i.e. target under test
+	// ---------------------------------------------------
+	//
+	// NOTE:
+	// 	Targeted CustomResources will be set in this namespace
+	targetNamespace, nsCreateErr := f.GetTypedClientset().CoreV1().Namespaces().Create(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNamespaceName,
+			},
+		},
+	)
+	if nsCreateErr != nil {
+		t.Fatal(nsCreateErr)
+	}
+
+	// ------------------------------------------------------
+	// Create target CRD & CR to trigger above generic controller
+	// ------------------------------------------------------
+	//
+	// Create a namespace scoped CoolNerd CRD & CR with finalizers
+	_, lnClient, _ := f.SetupNamespaceCRDAndItsCR(
+		"LocalNerd",
+		targetNamespace.GetName(),
+		targetResName,
+		framework.SetFinalizers([]string{"protect.abc.io", "protect.def.io"}),
+	)
+
+	// Need to wait & see if our controller works as expected
+	t.Logf("Waiting for verification of LocalNerd resource status")
+
+	waitCondErr := f.Wait(func() (bool, error) {
+		var errs []error
+
+		// -------------------------------------------
+		// verify if our custom resources are set with status
+		// -------------------------------------------
+		lnObj, getLNErr := lnClient.Namespace(targetNamespaceName).Get(targetResName, metav1.GetOptions{})
+		if getLNErr != nil {
+			errs = append(
+				errs, errors.Wrapf(getLNErr, "Get LocalNerd %s failed", targetResName),
+			)
+		}
+
+		// verify phase
+		phase, _, _ :=
+			unstructured.NestedString(lnObj.UnstructuredContent(), "status", "phase")
+		if phase != "Active" {
+			errs = append(errs, errors.Errorf("LocalNerd status is not 'Active'"))
+		}
+
+		// verify conditions
+		conditions, _, _ :=
+			unstructured.NestedStringSlice(lnObj.UnstructuredContent(), "status", "conditions")
+		if len(conditions) != 3 {
+			errs = append(errs, errors.Errorf("LocalNerd conditions count is not 3"))
+		}
+
+		// condition did not pass in case of any errors
+		if len(errs) != 0 {
+			return false, utilerrors.NewAggregate(errs)
+		}
+
+		// condition passed
+		return true, nil
+	})
+
+	if waitCondErr != nil {
+		t.Fatalf("Setting LocalNerd resource status failed: %v", waitCondErr)
+	}
+	t.Logf("Setting LocalNerd resource status was successful")
+}

--- a/test/integration/genericlocal/suite_test.go
+++ b/test/integration/genericlocal/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generic
+package genericlocal
 
 import (
 	"testing"
@@ -27,8 +27,18 @@ import (
 // call.
 //
 // NOTE:
-// 	framework.TestMain provides setup & teardown features required for
-// all the individual testcases to run.
+// 	`func TestMain(m *testing.M) {...}`
+// is the canonical golang way to execute the test functions
+// present in all *_test.go files in this package.
+//
+// NOTE:
+// 	framework.TestWithConfigMetac provides the common dependencies
+// like setup & teardown to let this test package run properly.
+//
+// NOTE:
+// 	Instead of directly invoking m.Run() where m is *testing.M this
+// function delegates to framework's TestWithConfigMetac which in
+// turn invokes m.Run()
 func TestMain(m *testing.M) {
-	framework.TestWithCRDMetac(m.Run)
+	framework.TestWithConfigMetac(m.Run)
 }


### PR DESCRIPTION
This commit found various issues w.r.t running metac in local mode. Local mode implies running metac using metacontroller as a config file versus using the same as a kubernetes CRD. These issues were
caught as a result of writing integration tests. Integration tests itself had to be enhanced to support this mode of metac.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>