### PR TITLE
[example] update set-status-on-cr example with README.md & test.sh

### DIFF
--- a/examples/gctl/set-status-on-cr/README.md
+++ b/examples/gctl/set-status-on-cr/README.md
@@ -11,13 +11,13 @@ is supposed to set status of a custom resource of kind `CoolNerd`.
 
 ```sh
 kubectl apply -f ns_and_crd.yaml
-kubectl create configmap set-status-on-cr --from-file=config
+kubectl apply -f rbac.yaml
 kubectl apply -f operator.yaml
 
 # verify if above was installed properly
 kubectl get ns
 kubectl get crd
-kubectl get deployment
+kubectl get deployment -n set-status-on-cr
 ```
 
 ### Create the Custom Resource
@@ -29,9 +29,7 @@ kubectl apply -f coolnerd.yaml
 Watch for the CR to get created with status
 
 ```sh
-kubectl get coolnerds --watch
-
-kubectl get coolnerds -oyaml
+kubectl get coolnerds -n set-status-on-cr -oyaml
 ```
 
 ### Cleanup
@@ -39,5 +37,6 @@ kubectl get coolnerds -oyaml
 ```sh
 kubectl delete -f coolnerd.yaml
 kubectl delete -f operator.yaml
+kubectl delete -f rbac.yaml
 kubectl delete -f ns_and_crd.yaml
 ```

--- a/examples/gctl/set-status-on-cr/coolnerd.yaml
+++ b/examples/gctl/set-status-on-cr/coolnerd.yaml
@@ -3,5 +3,5 @@ apiVersion: examples.metac.io/v1
 kind: CoolNerd
 metadata:
   name: cool-status-on-me
-  namespace: amitd
+  namespace: set-status-on-cr
 ---

--- a/examples/gctl/set-status-on-cr/ns_and_crd.yaml
+++ b/examples/gctl/set-status-on-cr/ns_and_crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: amitd
+  name: set-status-on-cr
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/examples/gctl/set-status-on-cr/operator.yaml
+++ b/examples/gctl/set-status-on-cr/operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: set-status-on-cr
-  namespace: default
+  namespace: set-status-on-cr
 spec:
   replicas: 1
   selector:
@@ -14,6 +14,7 @@ spec:
       labels:
         app: set-status-on-cr
     spec:
+      serviceAccountName: set-status-on-cr
       containers:
       - name: set-status-on-cr
         image: quay.io/amitkumardas/set-status-on-cr:latest
@@ -21,6 +22,6 @@ spec:
         args:
         - --logtostderr
         - --run-as-local
-        - -v=4
+        - -v=1
         - --discovery-interval=20s
 ---

--- a/examples/gctl/set-status-on-cr/rbac.yaml
+++ b/examples/gctl/set-status-on-cr/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: set-status-on-cr
+  namespace: set-status-on-cr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: set-status-on-cr
+rules:
+- apiGroups:
+  - examples.metac.io
+  resources:
+  - coolnerds
+  verbs:
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: set-status-on-cr
+subjects:
+- kind: ServiceAccount
+  name: set-status-on-cr
+  namespace: set-status-on-cr
+roleRef:
+  kind: ClusterRole
+  name: set-status-on-cr
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/examples/gctl/set-status-on-cr/test.sh
+++ b/examples/gctl/set-status-on-cr/test.sh
@@ -9,11 +9,10 @@ cleanup() {
   echo "++ Clean up started"
   echo "--------------------------"
 
-  kubectl patch namespace amitd --type=merge -p '{"metadata":{"finalizers":[]}}' || true
-  kubectl delete -f my-namespace.yaml || true
+  kubectl delete -f coolnerd.yaml || true
   kubectl delete -f operator.yaml || true
-  kubectl delete configmap install-uninstall-crd -n metac || true
-  kubectl delete crd storages.dao.amitd.io || true
+  kubectl delete -f rbac.yaml || true
+  kubectl delete -f ns_and_crd.yaml || true
   
   echo "--------------------------"
   echo "++ Clean up completed"
@@ -24,45 +23,35 @@ trap cleanup EXIT
 # Uncomment this if you want to run this script in debug mode
 #set -ex
 
-# my crd name
-my_crd="storages.dao.amitd.io"
+# my cr name
+my_res="cool-status-on-me"
+my_ns="set-status-on-cr"
 
 echo -e "\n++ Installing operator"
-kubectl create configmap install-uninstall-crd -n metac --from-file=hooks
+kubectl apply -f ns_and_crd.yaml
+kubectl apply -f rbac.yaml
 kubectl apply -f operator.yaml
 echo -e "\n++ Installed operator successfully"
 
 
-echo -e "\n++ Applying namespace that will get watched by metac - I"
-kubectl apply -f my-namespace.yaml
-echo -e "\n++ Applied namespace successfully"
+echo -e "\n++ Applying custom resource that gets watched by metac - I"
+kubectl apply -f coolnerd.yaml
+echo -e "\n++ Applied custom resource successfully"
 
-echo -e "\n++ Waiting for CRD $my_crd creation..."
-until kubectl get crd $my_crd; do sleep 1; done
-echo -e "\n++ CRD $my_crd created successfully"
+echo -e "\n++Waiting for custom resource's status to be updated"
+until [[ "$(kubectl -n $my_ns get coolnerd $my_res -o 'jsonpath={.status.phase}')" == "Active" ]]; do sleep 1; done
+echo -e "\n++Custom resource's status updated successfully"
 
-echo -e "\n++ Deleting namespace that is being watched by metac - II"
-kubectl delete -f my-namespace.yaml
-echo -e "\n++ Deleted namespace successfully"
+echo -e "\n++ Deleting custom resource that is watched by metac"
+kubectl delete -f coolnerd.yaml
+echo -e "\n++ Deleted custom resource successfully"
 
-echo -e "\n++ Waiting for CRD $my_crd deletion..."
-until [[ "$(kubectl get crd $my_crd 2>&1)" == *NotFound* ]]; do sleep 1; done
-echo -e "\n++ Deleted CRD $my_crd successfully"
+echo -e "\n++ Applying custom resource that gets watched by metac - II"
+kubectl apply -f coolnerd.yaml
+echo -e "\n++ Applied custom resource successfully"
 
-echo -e "\n++ Applying namespace that will get watched by metac - III"
-kubectl apply -f my-namespace.yaml
-echo -e "\n++ Applied namespace successfully"
+echo -e "\n++Waiting for custom resource's status to be updated"
+until [[ "$(kubectl -n $my_ns get coolnerd $my_res -o 'jsonpath={.status.phase}')" == "Active" ]]; do sleep 1; done
+echo -e "\n++Custom resource's status updated successfully"
 
-echo -e "\n++ Waiting for CRD $my_crd creation..."
-until kubectl get crd $my_crd; do sleep 1; done
-echo -e "\n++ CRD $my_crd created successfully"
-
-echo -e "\n++ Deleting namespace that is being watched by metac - IV"
-kubectl delete -f my-namespace.yaml
-echo -e "\n++ Deleted namespace successfully"
-
-echo -e "\n++ Waiting for CRD $my_crd deletion..."
-until [[ "$(kubectl get crd $my_crd 2>&1)" == *NotFound* ]]; do sleep 1; done
-echo -e "\n++ CRD $my_crd deleted successfully"
-
-echo -e "\n++ Test install-uninstall-crd completed successfully..."
+echo -e "\n++ Test set-status-on-cr completed successfully"


### PR DESCRIPTION
This commit showcases an example of a standalone binary that has the
following:
- uses metac as a library,
- uses GenericController as a config to run this binary &
- makes use of inline hook that implements the reconcile logic

Here reconcile logic is what the name of the folder suggests. In other words, the reconcile logic sets a custom resource's status.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>