### PR TITLE
[config] fix loading of metac config file(s)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -80,11 +81,23 @@ func (c *Config) Load() (MetacConfigs, error) {
 
 	// there can be multiple config files
 	for _, file := range files {
-		if file.IsDir() {
+		fileName := file.Name()
+		if file.IsDir() || file.Mode().IsDir() {
+			glog.V(4).Infof(
+				"Will skip metac config %s at path %s: Not a file", fileName, c.Path,
+			)
 			// we don't want to load directory
 			continue
 		}
-		fileNameWithPath := c.Path + file.Name()
+		if !strings.HasSuffix(fileName, ".yaml") && !strings.HasSuffix(fileName, ".json") {
+			glog.V(4).Infof(
+				"Will skip metac config %s at path %s: Not yaml or json", fileName, c.Path,
+			)
+			// we support either proper yaml or json file only
+			continue
+		}
+
+		fileNameWithPath := c.Path + fileName
 		glog.V(4).Infof("Will load metac config %s", fileNameWithPath)
 
 		contents, readFileErr := ioutil.ReadFile(fileNameWithPath)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,26 @@ import (
 	k8s "openebs.io/metac/third_party/kubernetes"
 )
 
+func TestConfigLoad(t *testing.T) {
+	config := &Config{
+		Path: "testdata/",
+	}
+	mConfigs, err := config.Load()
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v", err)
+	}
+	if len(mConfigs) != 3 {
+		t.Fatalf("Expected metac config count 3: Got %d", len(mConfigs))
+	}
+	gctls, err := mConfigs.ListGenericControllers()
+	if err != nil {
+		t.Fatalf("Expected no error while listing gctls: Got %v", err)
+	}
+	if len(gctls) != 1 {
+		t.Fatalf("Expected gctl count 1: Got %d", len(gctls))
+	}
+}
+
 func TestMetacConfigsListGeneric(t *testing.T) {
 	ul, err := k8s.YAMLToUnstructuredSlice([]byte(`
 ---

--- a/config/testdata/test_cctl.yaml
+++ b/config/testdata/test_cctl.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: bluegreen-controller
+spec:
+  parentResource:
+    apiVersion: ctl.enisoc.com/v1
+    resource: bluegreendeployments
+  childResources:
+  - apiVersion: v1
+    resource: services
+    updateStrategy:
+      method: InPlace
+  - apiVersion: extensions/v1beta1
+    resource: replicasets
+    updateStrategy:
+      method: InPlace
+  hooks:
+    sync:
+      webhook:
+        url: http://bluegreen-controller.metac/sync
+---

--- a/config/testdata/test_dctl.yaml
+++ b/config/testdata/test_dctl.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: DecoratorController
+metadata:
+  name: cluster-parent
+spec:
+  resources:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: clusterroles
+    annotationSelector:
+      matchExpressions:
+      - {key: default-service-account-binding, operator: Exists}
+  attachments:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: rolebindings
+  hooks:
+    sync:
+      webhook:
+        url: http://cluster-parent-controller.metacontroller/sync
+---

--- a/config/testdata/test_gctl.yaml
+++ b/config/testdata/test_gctl.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: set-status-on-cr
+spec:
+  watch:
+    apiVersion: examples.metac.io/v1
+    resource: coolnerds
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cool-nerd
+---

--- a/examples/gctl/uninstall-openebs/openebs_crs.yaml
+++ b/examples/gctl/uninstall-openebs/openebs_crs.yaml
@@ -14,6 +14,7 @@ apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
   name: storage-pool-read-default
+  namespace: openebs
   finalizers:
   - openebs-protect
 spec: 
@@ -64,6 +65,7 @@ apiVersion: openebs.io/v1alpha1
 kind: UpgradeTask
 metadata:
   name: my-upgrade
+  namespace: openebs
   finalizers:
   - openebs-protect
 ---
@@ -78,6 +80,7 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorCompletedBackup
 metadata:
   name: my-cstor-completed-backup
+  namespace: openebs
   finalizers:
   - openebs-protect
 ---
@@ -85,6 +88,7 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorVolumeReplica
 metadata:
   name: my-cstor-volume-replica
+  namespace: openebs
   finalizers:
   - openebs-protect
 ---
@@ -92,6 +96,7 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorVolumeClaim
 metadata:
   name: my-cstor-volume-claim
+  namespace: openebs
   finalizers:
   - openebs-protect
 ---
@@ -99,6 +104,7 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorVolume
 metadata:
   name: my-cstor-volume-claim
+  namespace: openebs
   finalizers:
   - openebs-protect
 ---

--- a/examples/gctl/uninstall-openebs/test.sh
+++ b/examples/gctl/uninstall-openebs/test.sh
@@ -30,6 +30,7 @@ openebs_ns="openebs"
 echo -e "\n++ Installing operator"
 kubectl apply -f operator_ns.yaml
 kubectl apply -f operator_rbac.yaml
+kubectl create configmap uninstall-openebs -n uninstall-openebs --from-file=config
 kubectl apply -f operator.yaml
 echo -e "\n++ Installed operator successfully"
 


### PR DESCRIPTION
This commit limits loading of metac config files with either .json or .yaml extension.

In addition, there is new unit test & some golden files to cover the same.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>