### PR TITLE
[fix] name of finalizer assigned to watch resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ These are some the features that metac supports:
     - GenericController (namespace scoped)
 - Business logic _(read reconciliation logic)_ can be exposed as http services
     - API based development as first class citizen
-- MetaControllers are defined as Kubernetes CustomResourceDefinitions
-- GenericController _(which is one of the meta controllers)_ can be either deployed as:
-    - Kubernetes CRD, or
-    - YAML config to metac binary
-- GenericController lets business logic invoked as in-line function call(s)
+- MetaControllers are deployed as Kubernetes custom resources
+    - However, GenericController _(one of the meta controllers)_ can either be deployed as:
+        - Kubernetes custom resources, or
+        - YAML config to metac binary
+- Ability to import metac as a go library
+    - GenericController lets business logic invoked as in-line function call(s)
     - This is an additional way to invoke logic other than http calls
     - Hence, no need to write reconcile logic as http services if not desired
 

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -170,6 +170,15 @@ func namespaceNameOrName(obj *unstructured.Unstructured) string {
 	return obj.GetName()
 }
 
+func namespaceNameOrNameFromMeta(obj metav1.Object) string {
+	if obj.GetNamespace() != "" {
+		return fmt.Sprintf(
+			"%s/%s", obj.GetNamespace(), obj.GetName(),
+		)
+	}
+	return obj.GetName()
+}
+
 // describeObject returns a human-readable string to identify a
 // given object.
 func describeObject(obj *unstructured.Unstructured) string {
@@ -189,6 +198,12 @@ func sanitiseAPIVersion(version string) string {
 // format corresponding to the given object
 func DescObjAsSanitisedNSName(obj *unstructured.Unstructured) string {
 	return strings.ReplaceAll(namespaceNameOrName(obj), "/", "-")
+}
+
+// DescMetaAsSanitisedNSName returns the sanitised namespace name
+// format corresponding to the given meta object
+func DescMetaAsSanitisedNSName(obj metav1.Object) string {
+	return strings.ReplaceAll(namespaceNameOrNameFromMeta(obj), "/", "-")
 }
 
 // DescObjectAsKey returns a machine readable string of the provided

--- a/controller/generic/controller.go
+++ b/controller/generic/controller.go
@@ -127,7 +127,8 @@ func newWatchController(
 			// This gets applied against the watch s.t GenericController
 			// has a chance to handle finalize hook i.e. handle deletion
 			// of watch resource
-			Name: "protect.gctl.metac.openebs.io/" + config.Namespace + "-" + config.Name,
+			Name: "protect.gctl.metac.openebs.io/" +
+				common.DescMetaAsSanitisedNSName(config.GetObjectMeta()),
 
 			// Enable if Finalize field is set in the generic controller
 			Enabled: config.Spec.Hooks.Finalize != nil,


### PR DESCRIPTION
This commit fixes the name of the finalizer to avoid namespace if the watch is not namespaced. This finalizer is set against watch resource declared in GenericController if there is a finalizer hook in the specs of GenericController.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>