### PR TITLE
[example] update rbac for uninstall-openebs example

### DIFF
--- a/examples/gctl/uninstall-openebs/go.mod
+++ b/examples/gctl/uninstall-openebs/go.mod
@@ -2,6 +2,6 @@ module openebs.io/uninstall-openebs
 
 go 1.12
 
-require openebs.io/metac v0.1.1-0.20191110151702-ee6f73539e50
+require openebs.io/metac v0.1.1-0.20191111053549-a74a6feadbd6
 
-replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20191110151702-ee6f73539e50
+replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6

--- a/examples/gctl/uninstall-openebs/go.sum
+++ b/examples/gctl/uninstall-openebs/go.sum
@@ -3,8 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE5H/ukPWBRo314xiDvg=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
-github.com/AmitKumarDas/metac v0.1.1-0.20191110151702-ee6f73539e50 h1:koGYuc6VbmuZAM75tpKDiAcP0NtGQ/GfMWSLDu74+bg=
-github.com/AmitKumarDas/metac v0.1.1-0.20191110151702-ee6f73539e50/go.mod h1:H41I6LvGQp81HGiMm9QeiYjA+mV/rx8TNvbyrLWm630=
+github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6 h1:ZLA93rGInJmzsfR0Ow3t4bIF/JzI4x1ujGgSPW7OeB4=
+github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6/go.mod h1:H41I6LvGQp81HGiMm9QeiYjA+mV/rx8TNvbyrLWm630=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/examples/gctl/uninstall-openebs/openebs_crs.yaml
+++ b/examples/gctl/uninstall-openebs/openebs_crs.yaml
@@ -4,7 +4,7 @@ kind: CASTemplate
 metadata:
   name: storage-pool-read-default
 spec: 
-  taskNamespace: {{ env "OPENEBS_NAMESPACE" }}
+  taskNamespace: something
   run:
     tasks:
     - storage-pool-read-default
@@ -103,7 +103,7 @@ metadata:
 apiVersion: openebs.io/v1alpha1
 kind: CStorVolume
 metadata:
-  name: my-cstor-volume-claim
+  name: my-cstor-volume
   namespace: openebs
   finalizers:
   - openebs-protect

--- a/examples/gctl/uninstall-openebs/operator_rbac.yaml
+++ b/examples/gctl/uninstall-openebs/operator_rbac.yaml
@@ -10,10 +10,28 @@ metadata:
   name: uninstall-openebs
 rules:
 - apiGroups:
-  - openebs.io
+  - "openebs.io"
   resources:
-  - castemplates
+  - "*"
   verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - "*"
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
   - list
   - update
 ---


### PR DESCRIPTION
This commit updates the rbac rules required to run uninstall openebs example. In addition, it updates to use the latest version of metac. It is important to make use of this latest metac since that includes a bug fix.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>