### PR TITLE
[example] fix example on uninstall openebs

### DIFF
--- a/examples/gctl/uninstall-openebs/config/config.yaml
+++ b/examples/gctl/uninstall-openebs/config/config.yaml
@@ -3,6 +3,12 @@ kind: GenericController
 metadata:
   name: uninstall-openebs
 spec:
+  # controller should be able to update attachments
+  # i.e. remove finalizers if any
+  updateAny: true
+  # controller should be able to remove attachments
+  # i.e. remove custom resources & then their definitions
+  deleteAny: true
   # controller keeps a watch on namespace resource
   watch:
     apiVersion: v1

--- a/examples/gctl/uninstall-openebs/operator_rbac.yaml
+++ b/examples/gctl/uninstall-openebs/operator_rbac.yaml
@@ -14,26 +14,19 @@ rules:
   resources:
   - "*"
   verbs:
-  - get
-  - list
-  - update
-- apiGroups:
   - "*"
+- apiGroups:
+  - ""
   resources:
   - namespaces
   verbs:
-  - get
-  - list
-  - watch
-  - update
+  - "*"
 - apiGroups:
   - "apiextensions.k8s.io"
   resources:
   - customresourcedefinitions
   verbs:
-  - get
-  - list
-  - update
+  - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This commit fixes the logic w.r.t uninstall openebs example. It sets hook response's Finalized state to true if there are no attachments in the hook request. This in turn removes metac's finalizer from namespace and lets this namespace to get deleted.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>