### PR TITLE
[gctl] add UpdateDuringPendingDelete option

### DIFF
--- a/controller/generic/controller.go
+++ b/controller/generic/controller.go
@@ -724,6 +724,16 @@ func (mgr *watchController) syncWatchObj(watch *unstructured.Unstructured) error
 				Watch:                      watch,
 				UpdateAny:                  mgr.GCtlConfig.Spec.UpdateAny,
 				DeleteAny:                  mgr.GCtlConfig.Spec.DeleteAny,
+
+				// TODO (@amitkumardas):
+				//
+				// Need to decide if this field should be part of
+				// GenericController specs like UpdateAny & DeleteAny?
+				//
+				// This is currently set to true if this request is being
+				// processed by finalize hook. In other words, this is set
+				// to true during finalize hook invocation.
+				UpdateDuringPendingDelete: k8s.BoolPtr(syncRequest.Finalizing),
 			},
 
 			DynamicClientSet: mgr.DynamicClientSet,


### PR DESCRIPTION
This commit adds a new option that allows metac to update a resource even if this resource is pending deletion. This option is currently only supported in GenericController during finalize hook invocation.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>