### PR TITLE
[example] update uninstall openebs example to latest metac

### DIFF
--- a/examples/gctl/uninstall-openebs/config/config.yaml
+++ b/examples/gctl/uninstall-openebs/config/config.yaml
@@ -34,33 +34,61 @@ spec:
     - cstorcompletedbackups.openebs.io
     - cstorrestores.openebs.io
     - upgradetasks.openebs.io
+    updateStrategy:
+      method: InPlace
   # controller needs to deal with openebs custom resources only
   - apiVersion: openebs.io/v1alpha1
     resource: castemplates
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: runtasks
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: storagepoolclaims
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorpoolinstances
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: storagepools
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorpools
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorvolumes
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorvolumeclaims
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorvolumereplicas
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorbackups
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorcompletedbackups
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: cstorrestores
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: upgradetasks
+    updateStrategy:
+      method: InPlace
   hooks:
     # controller gets triggered only when the watch resource
     # i.e. openebs namespace is being deleted

--- a/examples/gctl/uninstall-openebs/go.mod
+++ b/examples/gctl/uninstall-openebs/go.mod
@@ -2,6 +2,6 @@ module openebs.io/uninstall-openebs
 
 go 1.12
 
-require openebs.io/metac v0.1.1-0.20191111053549-a74a6feadbd6
+require openebs.io/metac v0.1.1-0.20191112035947-4ea7d563defc
 
-replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6
+replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20191112035947-4ea7d563defc

--- a/examples/gctl/uninstall-openebs/go.sum
+++ b/examples/gctl/uninstall-openebs/go.sum
@@ -3,8 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE5H/ukPWBRo314xiDvg=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
-github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6 h1:ZLA93rGInJmzsfR0Ow3t4bIF/JzI4x1ujGgSPW7OeB4=
-github.com/AmitKumarDas/metac v0.1.1-0.20191111053549-a74a6feadbd6/go.mod h1:H41I6LvGQp81HGiMm9QeiYjA+mV/rx8TNvbyrLWm630=
+github.com/AmitKumarDas/metac v0.1.1-0.20191112035947-4ea7d563defc h1:PSsRDQicVEoU+6iW7th4FK3G6okzHwB5U0xW1/o3juA=
+github.com/AmitKumarDas/metac v0.1.1-0.20191112035947-4ea7d563defc/go.mod h1:H41I6LvGQp81HGiMm9QeiYjA+mV/rx8TNvbyrLWm630=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=


### PR DESCRIPTION
This commit updates uninstall openebs code to point to latest metac. In addition, it updates the GenericController config to use appropriate update strategy.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>