### PR TITLE
Update Go in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,28 @@
+# Tester image
+FROM golang:1.13.5 as tester
+
+WORKDIR /go/src/openebs.io/metac/
+
+# copy go modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# ensure vendoring is up-to-date by running make vendor in your local
+# setup
+#
+# we cache the vendored dependencies before building and copying source
+# so that we don't need to re-download when source changes don't invalidate
+# our downloaded layer
+RUN GO111MODULE=on go mod download
+RUN GO111MODULE=on go mod vendor
+
+# copy build manifests
+COPY . .
+
+RUN make integration-test
+
 # Build metac binary
-FROM golang:1.12.5 as builder
+FROM golang:1.13.5 as builder
 
 WORKDIR /go/src/openebs.io/metac/
 
@@ -22,6 +45,7 @@ COPY Makefile Makefile
 # copy source files
 COPY *.go ./
 COPY apis/ apis/
+COPY client/ client/
 COPY config/ config/
 COPY hack/ hack/
 COPY controller/ controller/


### PR DESCRIPTION
Resolve #72 
- Updated version of Go to 1.13.5 in Dockerfile
- Add Pre-test image to the Dockerfile to make sure it's working with 1.13.5