### PR TITLE
examples(sample-controller): add javascript based sample controller

### DIFF
--- a/examples/sample-controller/js/README.md
+++ b/examples/sample-controller/js/README.md
@@ -1,0 +1,65 @@
+## Sample Controller
+
+This is Metacontroller implementation of SampleController found at https://github.com/kubernetes/sample-controller/. 
+
+Sample controller provides a simple implementation of Kubernetes extension (i.e. custom controller). It defines a custom resource of kind `Foo`. When an instance of Foo gets applied against Kubernetes cluster, it is expected to create a Deployment instance. There should be a deployment instance corresponding to each instance of Foo.
+
+This version of SampleController shows how a controller needs to be bother about constructing its desired state only. In other words, controller logic returns the desired 'Deployment' object from the observed Foo instance without bothering about inner details of Kubernetes. Metacontroller on its parts handles create, update & delete operations of the Deployment instance based on Foo instance's current state.
+
+This example also provides a fair idea to write idempotent logic required to implement Kubernetes controllers.
+
+### Prerequisites
+
+* Install Metac from the repo's `manifests` folder
+```sh
+kubectl apply -f ../../../manifests/
+```
+
+```sh
+# verify presence of metac CRDs
+kubectl get crd
+
+# verify presence of metac controller
+kubectl get sts -n metac
+```
+
+### Deploy the BlueGreen controller
+
+```sh
+# embed javascript controller logic into a configmap
+kubectl create configmap sample-controller -n metac --from-file=sync.js
+# apply NodeJS image that mounts above javascript controller code
+kubectl apply -f operator.yaml
+
+# verify presence of Foo CRD
+kubectl get crd | grep foos
+
+# verify presence of Foo controller deployment & service
+kubectl get deploy -n metac
+kubectl get svc -n metac
+```
+
+### Create a Foo resource
+
+```sh
+kubectl apply -f foo.yaml
+```
+
+### Verify creation of resources
+```sh
+kubectl get foo
+kubectl get deploy
+kubectl get po
+```
+
+### Delete the Foo resource
+```sh
+kubectl delete -f foo.yaml
+```
+
+### Verify deletion of deployment object
+```sh
+kubectl get foo
+kubectl get deploy
+kubectl get po
+```

--- a/examples/sample-controller/js/foo.yaml
+++ b/examples/sample-controller/js/foo.yaml
@@ -1,0 +1,9 @@
+apiVersion: samplecontroller.k8s.io/v1alpha1
+kind: Foo
+metadata:
+  name: myfoo
+  labels:
+    app: myfoo
+spec:
+  deploymentName: my-deploy
+  replicas: 3

--- a/examples/sample-controller/js/operator.yaml
+++ b/examples/sample-controller/js/operator.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.k8s.io
+spec:
+  group: samplecontroller.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: foos
+    singular: foo
+    kind: Foo
+    shortNames:
+    - foo
+  subresources:
+    status: {}
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: sample-controller
+spec:
+  generateSelector: true
+  parentResource:
+    apiVersion: samplecontroller.k8s.io/v1alpha1
+    resource: foos
+  childResources:
+  - apiVersion: apps/v1
+    resource: deployments
+    updateStrategy:
+      method: InPlace
+  hooks:
+    sync:
+      webhook:
+        url: http://sample-controller.metac/sync
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-controller
+  namespace: metac
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-controller
+  template:
+    metadata:
+      labels:
+        app: sample-controller
+    spec:
+      containers:
+      - name: controller
+        image: metacontroller/nodejs-server:0.1
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: hooks
+          mountPath: /node/hooks
+      volumes:
+      - name: hooks
+        configMap:
+          name: sample-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-controller
+  namespace: metac
+spec:
+  selector:
+    app: sample-controller
+  ports:
+  - port: 80

--- a/examples/sample-controller/js/sync.js
+++ b/examples/sample-controller/js/sync.js
@@ -1,0 +1,79 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+var desiredDeployment = function (foo) {
+  let lbls = {
+    app: 'nginx',
+    controller: foo.metadata.name
+  }
+  let deploy = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: foo.spec.deploymentName,
+      namespace: foo.metadata.namespace
+    },
+    spec: {
+      replicas: foo.spec.replicas,
+      selector: {
+        matchLabels: lbls
+      },
+      template: {
+        metadata: {
+          labels: lbls
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nginx',
+              image: 'nginx:latest'
+            }
+          ]
+        }
+      }
+    }
+  };
+  return deploy;
+};
+
+module.exports = async function (context) {
+  let observed = context.request.body;
+  let desired = {status: {}, children: []};
+
+  try {
+    // observed foo object
+    let foo = observed.parent;
+
+    // extract available replicas from desired deployment if available
+    let allDeploys = observed.children['Deployment.apps/v1'];
+    let fooDeploy = allDeploys ? allDeploys[foo.spec.deploymentName] : null;
+    let replicas = fooDeploy ? fooDeploy.status.availableReplicas : 0;
+
+    // Set the status of Foo
+    desired.status = {
+      availableReplicas: replicas
+    };
+
+    // Generate/Apply desired children
+    desired.children = [
+      desiredDeployment(foo)
+    ];
+  } catch (e) {
+    return {status: 500, body: e.stack};
+  }
+
+  return {status: 200, body: desired, headers: {'Content-Type': 'application/json'}};
+};

--- a/examples/sample-controller/js/test.sh
+++ b/examples/sample-controller/js/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+cleanup() {
+  set +e
+  echo ""
+
+  echo "--------------------------"
+  echo "++ Clean up started"
+  echo "--------------------------"
+
+  kubectl delete -f foo.yaml || true
+  kubectl delete -f operator.yaml || true
+  kubectl delete configmap sample-controller -n metac || true
+
+  echo "--------------------------"
+  echo "++ Clean up completed"
+  echo "--------------------------"
+}
+
+# Comment below if you want to check manually
+# the state of the cluster and intended resources
+trap cleanup EXIT
+
+# Uncomment below if debug / verbose execution is needed
+#set -ex
+
+my_crd="foos.samplecontroller.k8s.io"
+my_deploy="my-deploy"
+
+echo -e "\n Install SampleController..."
+kubectl create configmap sample-controller -n metac --from-file=sync.js
+kubectl apply -f operator.yaml
+
+echo -e "\n Wait until SampleController $my_crd is available..."
+until kubectl get $my_crd; do sleep 1; done
+
+echo -e "\n Create a Foo object..."
+kubectl apply -f foo.yaml
+
+echo -e "\n Wait for Foo deployment to be available..."
+until kubectl get deploy $my_deploy; do sleep 1; done
+
+echo -e "\n Wait for Foo deployment's pods to be available..."
+until [[ "$(kubectl get deploy $my_deploy -o 'jsonpath={.status.availableReplicas}')" -eq 3 ]]; do sleep 1; done
+
+echo -e "\n Delete the Foo object..."
+kubectl delete -f foo.yaml
+
+echo -e "\n++ Waiting for Foo Deployment deletion..."
+until [[ "$(kubectl get deploy $my_deploy 2>&1)" == *NotFound* ]]; do sleep 1; done


### PR DESCRIPTION
This commit adds a new example that compares the Metacontroller way of writing controllers versus the one present at: https://github.com/kubernetes/sample-controller

This is the javascript version of sample controller. We might include `python` & `go` versions in near future.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>