### PR TITLE
feat(advanced selector): add more selector options to GenericController

### DIFF
--- a/apis/metacontroller/v1alpha1/types.go
+++ b/apis/metacontroller/v1alpha1/types.go
@@ -53,8 +53,13 @@ type CompositeControllerSpec struct {
 
 // ResourceRule helps in identifying the type of the API resource
 type ResourceRule struct {
+	// APIVersion is the combination of group & version
+	// of the resource
 	APIVersion string `json:"apiVersion"`
-	Resource   string `json:"resource"`
+
+	// Resource is the name of the resource. Its also
+	// the plural of Kind
+	Resource string `json:"resource"`
 }
 
 type CompositeControllerParentResourceRule struct {

--- a/apis/metacontroller/v1alpha1/types_generic.go
+++ b/apis/metacontroller/v1alpha1/types_generic.go
@@ -167,7 +167,13 @@ type GenericControllerResource struct {
 	// Include the resource if resource selector matches
 	//
 	// This is ANDed with other selectors if present
-	ResourceSelector *ResourceSelector `json:"resourceSelector,omitempty"`
+	//
+	// NOTE:
+	//	This is an advanced selector & can be used to perform
+	// matches on complex selection criterias against combinations
+	// of labels, annotations, name, namespace, target object,
+	// path & slice values.
+	AdvancedSelector *ResourceSelector `json:"advancedSelector,omitempty"`
 }
 
 // GenericControllerAttachment represents a resources that takes
@@ -290,9 +296,9 @@ type GenericControllerList struct {
 	Items           []GenericController `json:"items"`
 }
 
-// Key formats the GenericController value into a
-// suitable key format
-func (gc GenericController) Key() string {
+// AsNamespaceNameKey formats the GenericController value into a
+// suitable key format that makes use of namespace & name
+func (gc GenericController) AsNamespaceNameKey() string {
 	return GenericControllerKey(gc.Namespace, gc.Name)
 }
 

--- a/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/metacontroller/v1alpha1/zz_generated.deepcopy.go
@@ -787,8 +787,8 @@ func (in *GenericControllerResource) DeepCopyInto(out *GenericControllerResource
 		*out = new(AnnotationSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ResourceSelector != nil {
-		in, out := &in.ResourceSelector, &out.ResourceSelector
+	if in.AdvancedSelector != nil {
+		in, out := &in.AdvancedSelector, &out.AdvancedSelector
 		*out = new(ResourceSelector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/controller/common/finalizer/finalizer.go
+++ b/controller/common/finalizer/finalizer.go
@@ -38,7 +38,8 @@ type Finalizer struct {
 // SyncObject reconciles i.e. adds or removes the finalizer on
 // the given object as necessary.
 func (m *Finalizer) SyncObject(
-	client *dynamicclientset.ResourceClient, obj *unstructured.Unstructured,
+	client *dynamicclientset.ResourceClient,
+	obj *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {
 	// If the cached object passed in is already in the right state,
 	// we'll assume we don't need to check the live object.
@@ -51,7 +52,6 @@ func (m *Finalizer) SyncObject(
 	if dynamicobject.HasFinalizer(obj, m.Name) == m.Enabled {
 		return obj, nil
 	}
-
 	// Otherwise, we may need to update the object.
 	//
 	// NOTE:

--- a/controller/common/selector/evaluator.go
+++ b/controller/common/selector/evaluator.go
@@ -37,7 +37,7 @@ type Evaluation struct {
 	// Selector terms that forms the evaluation logic against the target
 	Terms []*v1alpha1.SelectorTerm
 
-	// In some cases, the evaluation of a target is possible by comparing
+	// In some cases, the evaluation of a target is performed by comparing
 	// the results of evaluation against another resource.
 	//
 	// NOTE:
@@ -47,7 +47,7 @@ type Evaluation struct {
 }
 
 // RunMatch flags the given target as a match or no match (represented as
-// true or false correspondingly) by executing this target against all
+// true or false correspondingly) by executing this target against **all**
 // the SelectTerm(s).
 //
 // NOTE:
@@ -65,20 +65,14 @@ func (e Evaluation) RunMatch() (bool, error) {
 	}
 
 	// NOTE:
-	// 	One match function deals with specific match expression(s)
-	// from a SelectTerm. However, running all the match functions
-	// together ensures evaluation of all match expressions present
-	// in the SelectTerm.
+	// 	A match function corresponds to specific match expression
+	// found in a SelectTerm. Running all the match functions
+	// can evaluate if this SelectTerm passed or failed the evaluation.
 	//
 	// NOTE:
-	// 	Match expressions are found in SelectTerm
-	//
-	// NOTE:
-	//	Match functions are implemented in such a way that they return
-	// true if one or more match expression(s) is not specified. This
-	// handles the cases when a SelectTerm may not specify one or more
-	// match expressions, since each match expression within a SelectTerm
-	// is optional.
+	//	A match function returns true if its match expression(s) is not
+	// specified. A SelectTerm need not specify all the match expressions,
+	// since each match expression within a SelectTerm can be optional.
 	matchFns := []func(v1alpha1.SelectorTerm) (bool, error){
 		e.isFieldMatch,
 		e.isAnnotationMatch,
@@ -88,32 +82,36 @@ func (e Evaluation) RunMatch() (bool, error) {
 	}
 	matchFnsCount := len(matchFns)
 
-	// Matching SelectTerms are ORed against the target. Hence if any
+	// Matching SelectTerms are **ORed** against the target. Hence if any
 	// SelectTerm is a match i.e. if any iteration has a successful match,
 	// the overall match is a success & returns true
 	for _, selectTerm := range e.Terms {
 		if selectTerm == nil {
+			// nothing to be done
+			//
+			// NOTE:
+			//	Ideally a SelectTerm should not be nil
 			continue
 		}
 
-		// this is a counter which if equal to number of
-		// successful match functions implies the term's
-		// match was a success
+		// counter to check if it equals successful match functions
+		// which in turn implies this SelectTerm match was a success
 		successfulSelectTermCount := 0
 
-		// Each match specified in a term are ANDed
+		// Each match specified in a SelectTerm are ANDed
 		//
-		// One of more match expressions declared in a SelectTerm
-		// are executed via match functions
+		// NOTE:
+		// 	One of more match expressions found in a SelectTerm
+		// are executed via corresponding match functions
 		for _, match := range matchFns {
 			isMatch, err := match(*selectTerm)
 			if err != nil {
 				return false, err
 			}
 			if !isMatch {
-				// Since each match within a term is an AND operation,
-				// a failed match function implies current SelectTerm
-				// failed. Hence ignore the current term & evaluate the
+				// Since each match within a SelectTerm AND-ed,
+				// any failed match implies current SelectTerm failed.
+				// Hence ignore the current term & evaluate the
 				// next SelectTerm.
 				//
 				// Technically speaking, this breaks the current for loop
@@ -123,16 +121,16 @@ func (e Evaluation) RunMatch() (bool, error) {
 			successfulSelectTermCount++
 		}
 
-		// check whether all match expressions in the current term
+		// check whether all match expressions in the current SelectTerm
 		// succeeded
 		if successfulSelectTermCount == matchFnsCount {
-			// no need to check for other terms since
+			// no need to check for subsequent SelectTerms since
 			// terms are ORed
 			return true, nil
 		}
 	}
-
-	// at this point no terms would have succeeded
+	// at this point no SelectTerm(s) would have succeeded
+	// hence fail this evaluation
 	return false, nil
 }
 
@@ -196,62 +194,18 @@ func (e *Evaluation) isFieldMatch(term v1alpha1.SelectorTerm) (bool, error) {
 	if len(term.MatchFields)+len(term.MatchFieldExpressions) == 0 {
 		// Match is true if there are no field expressions
 		//
-		// Note that these expressions are optional
+		// Note that field selector expressions are optional
 		return true, nil
 	}
-
 	if e.Target == nil {
-		return false, errors.Errorf("Evaluation failed: Nil target")
+		return false, errors.Errorf("Field match failed: Nil target")
 	}
-
-	// label selector can be used for field expressions
-	sel := &metav1.LabelSelector{
+	// field selector piggy backs on label selector
+	sel := NewFieldSelector(&metav1.LabelSelector{
 		MatchLabels:      term.MatchFields,
 		MatchExpressions: term.MatchFieldExpressions,
-	}
-	fieldSel, err := metav1.LabelSelectorAsSelector(sel)
-	if err != nil {
-		return false, errors.Wrapf(err, "Invalid field expressions: %v", sel)
-	}
-
-	// real logic w.r.t field based matches starts here
-	var allKeys []string
-	for kfield := range term.MatchFields {
-		if kfield == "" {
-			return false,
-				errors.Wrapf(err, "Invalid field expressions: Missing key: %v", term.MatchFields)
-		}
-		allKeys = append(allKeys, kfield)
-	}
-	for _, kexp := range term.MatchFieldExpressions {
-		if kexp.Key == "" {
-			return false,
-				errors.Wrapf(err, "Invalid field expressions: Missing key: %v", kexp)
-		}
-		allKeys = append(allKeys, kexp.Key)
-	}
-
-	// fill up given selector keys with actual values
-	// from the target
-	keyValues := make(map[string]string)
-	for _, key := range allKeys {
-		fields := strings.Split(key, ".")
-		val, found, err := unstructured.NestedString(e.Target.Object, fields...)
-		if err != nil {
-			return false, errors.Wrapf(err, "Field expressions match for key %s failed", key)
-		}
-		if found {
-			// add key if and only if the key is found
-			//
-			// NOTE:
-			// 	This is helpful for cases where match is being
-			// made from 'Exists' or 'DoesNotExist' operator
-			keyValues[key] = val
-		}
-	}
-
-	// at this point field expressions are made same as label expressions
-	return fieldSel.Matches(labels.Set(keyValues)), nil
+	})
+	return sel.Match(e.Target)
 }
 
 // isSliceMatch runs slice expressions against the target
@@ -271,35 +225,51 @@ func (e *Evaluation) isSliceMatch(term v1alpha1.SelectorTerm) (bool, error) {
 		return false, errors.Errorf("Evaluation failed: Nil target")
 	}
 
-	configDesired := SliceSelectorConfig{
+	config := SliceSelectorConfig{
 		MatchSlice:            term.MatchSlice,
 		MatchSliceExpressions: term.MatchSliceExpressions,
 	}
-	desiredSliceSelector, err := NewSliceSelector(configDesired)
+	sliceSelector, err := NewSliceSelector(config)
 	if err != nil {
-		return false, errors.Wrapf(err, "Invalid slice expressions: %v", configDesired)
+		return false, errors.Wrapf(err, "Invalid slice expressions: %v", config)
 	}
 
-	// fill up specified selector keys with actual values
-	// from the target
-	targetSlice := make(map[string][]string)
-	for _, kexp := range term.MatchSliceExpressions {
-		if kexp.Key == "" {
+	// fill up specified selector keys with **actual** values
+	// from the target & build a new target that can
+	// be evaluated in terms of slice matches
+	newTarget := make(map[string][]string)
+	for _, sExp := range term.MatchSliceExpressions {
+		if sExp.Key == "" {
 			return false,
-				errors.Errorf("Invalid slice expressions: Missing key: %v", kexp)
+				errors.Errorf("Invalid match slice expressions: Missing key: %v", sExp)
 		}
-		fields := strings.Split(kexp.Key, ".")
+		fields := strings.Split(sExp.Key, ".")
 
 		// extract actual value(s) from target
-		vals, _, err := unstructured.NestedStringSlice(e.Target.Object, fields...)
+		actualVals, _, err := unstructured.NestedStringSlice(e.Target.Object, fields...)
 		if err != nil {
 			return false,
-				errors.Wrapf(err, "Slice expressions match for key %s failed", kexp.Key)
+				errors.Wrapf(err, "Match slice expressions failed: Key %s", sExp.Key)
 		}
-		targetSlice[kexp.Key] = vals
+		newTarget[sExp.Key] = actualVals
 	}
+	for key := range term.MatchSlice {
+		if key == "" {
+			return false,
+				errors.Errorf("Invalid match slice: Missing key: %s", key)
+		}
+		fields := strings.Split(key, ".")
 
-	return desiredSliceSelector.Match(targetSlice), nil
+		// extract actual value(s) from target
+		actualVals, _, err := unstructured.NestedStringSlice(e.Target.Object, fields...)
+		if err != nil {
+			return false,
+				errors.Wrapf(err, "Slice match failed: Key %s", key)
+		}
+		newTarget[key] = actualVals
+	}
+	// run the match against this newly built target
+	return sliceSelector.Match(newTarget), nil
 }
 
 // isReferenceMatch runs reference expressions against the target's

--- a/controller/common/selector/evaluator_test.go
+++ b/controller/common/selector/evaluator_test.go
@@ -353,6 +353,78 @@ func TestEvalIsLabelMatch(t *testing.T) {
 			isError: false,
 			isMatch: true,
 		},
+		"MatchLabels selector && matching labels && value has -": {
+			selector: v1alpha1.SelectorTerm{
+				MatchLabels: map[string]string{
+					"app": "trial-1",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "trial-1",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchLabels selector && matching labels && special char .": {
+			selector: v1alpha1.SelectorTerm{
+				MatchLabels: map[string]string{
+					"app.io": "trial",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app.io": "trial",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchLabels selector && matching labels && special char /": {
+			selector: v1alpha1.SelectorTerm{
+				MatchLabels: map[string]string{
+					"app/io": "trial",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app/io": "trial",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchLabels selector && matching labels && special char / and .": {
+			selector: v1alpha1.SelectorTerm{
+				MatchLabels: map[string]string{
+					"app.io/type": "trial",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app.io/type": "trial",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
 		"Match && Expression label selector && matching labels": {
 			selector: v1alpha1.SelectorTerm{
 				MatchLabels: map[string]string{
@@ -635,7 +707,76 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 		isError  bool
 		isMatch  bool
 	}{
-		"Match all finalizers via In operator": {
+		"Match two finalizers of three": {
+			selector: v1alpha1.SelectorTerm{
+				MatchSlice: map[string][]string{
+					"metadata.finalizers": []string{
+						"pvc-protect",
+						"app-protect",
+					},
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"pvc-protect",
+							"storage-protect",
+							"app-protect",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: false,
+		},
+		"Match one finalizer of three": {
+			selector: v1alpha1.SelectorTerm{
+				MatchSlice: map[string][]string{
+					"metadata.finalizers": []string{
+						"pvc-protect",
+					},
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"pvc-protect",
+							"storage-protect",
+							"app-protect",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: false,
+		},
+		"Match all finalizers": {
+			selector: v1alpha1.SelectorTerm{
+				MatchSlice: map[string][]string{
+					"metadata.finalizers": []string{
+						"pvc-protect",
+						"storage-protect",
+						"app-protect",
+					},
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"pvc-protect",
+							"storage-protect",
+							"app-protect",
+						},
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"Match all finalizers + In operator": {
 			selector: v1alpha1.SelectorTerm{
 				MatchSliceExpressions: []v1alpha1.SliceSelectorRequirement{
 					v1alpha1.SliceSelectorRequirement{
@@ -659,7 +800,7 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 			isError: false,
 			isMatch: true,
 		},
-		"Match all finalizers via Equals operator": {
+		"Match all finalizers + Equals operator": {
 			selector: v1alpha1.SelectorTerm{
 				MatchSliceExpressions: []v1alpha1.SliceSelectorRequirement{
 					v1alpha1.SliceSelectorRequirement{
@@ -683,7 +824,7 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 			isError: false,
 			isMatch: true,
 		},
-		"Match no finalizers via NotIn operator": {
+		"Match no finalizers + NotIn operator": {
 			selector: v1alpha1.SelectorTerm{
 				MatchSliceExpressions: []v1alpha1.SliceSelectorRequirement{
 					v1alpha1.SliceSelectorRequirement{
@@ -707,7 +848,7 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 			isError: false,
 			isMatch: true,
 		},
-		"Match no finalizers via NotEquals operator": {
+		"Match no finalizers + NotEquals operator": {
 			selector: v1alpha1.SelectorTerm{
 				MatchSliceExpressions: []v1alpha1.SliceSelectorRequirement{
 					v1alpha1.SliceSelectorRequirement{
@@ -731,7 +872,7 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 			isError: false,
 			isMatch: true,
 		},
-		"Match all finalizers via all operators": {
+		"Match all finalizers + All operators": {
 			selector: v1alpha1.SelectorTerm{
 				MatchSliceExpressions: []v1alpha1.SliceSelectorRequirement{
 					v1alpha1.SliceSelectorRequirement{
@@ -864,6 +1005,9 @@ func TestEvalIsSliceMatchFinalizers(t *testing.T) {
 			if !mock.isError && err != nil {
 				t.Fatalf("%s: Expected no error: Got %v", name, err)
 			}
+			if mock.isError {
+				return
+			}
 			if mock.isMatch && !match {
 				t.Fatalf("%s: Expected match: Got no match", name)
 			}
@@ -902,6 +1046,70 @@ func TestEvalIsFieldMatch(t *testing.T) {
 			target:  nil,
 			isError: true,
 			isMatch: false,
+		},
+		"MatchFields selector && matching target": {
+			selector: v1alpha1.SelectorTerm{
+				MatchFields: map[string]string{
+					"spec.path": "my-path",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"path": "my-path",
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchFields selector && matching target && value with /": {
+			selector: v1alpha1.SelectorTerm{
+				MatchFields: map[string]string{
+					"spec.path": "/dev/sdb",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"path": "/dev/sdb",
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchFields selector && matching target && value with numbers": {
+			selector: v1alpha1.SelectorTerm{
+				MatchFields: map[string]string{
+					"spec.path": "1234",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"path": "1234",
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
+		},
+		"MatchFields selector && matching target && value is like uuid": {
+			selector: v1alpha1.SelectorTerm{
+				MatchFields: map[string]string{
+					"spec.path": "1234-1232-asdfssed-12esee-212",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"path": "1234-1232-asdfssed-12esee-212",
+					},
+				},
+			},
+			isError: false,
+			isMatch: true,
 		},
 		"MatchFields selector && matching fields": {
 			selector: v1alpha1.SelectorTerm{

--- a/controller/common/selector/field.go
+++ b/controller/common/selector/field.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selector
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// replaceValueStrings maps various strings which if
+// present in field value(s) to their replacement
+//
+// NOTE:
+//	This ensures the values are valid when matched
+// via labels.Selector
+//
+// NOTE:
+//	FieldSelection delegates the match implementation
+// to labels.Selector
+var replaceValueStrings = map[string]string{
+	"/": "fwdslash",
+}
+
+// FieldSelection helps in matching field paths against
+// given target objects
+//
+// It piggy backs on label selector with minor changes to
+// label selector's logic
+type FieldSelection struct {
+	selector  labels.Selector
+	fieldKeys []string
+
+	err error
+}
+
+func (s *FieldSelection) sanitiseValue(given string) string {
+	if given == "" {
+		return ""
+	}
+	newvalue := given
+	for old, new := range replaceValueStrings {
+		newvalue = strings.ReplaceAll(newvalue, old, new)
+	}
+	return newvalue
+}
+
+// sanitiseLabels replaces one or more special chars from
+// values with chars that are considered valid by
+// labels.Selector
+func (s *FieldSelection) sanitiseLabels(lbls *metav1.LabelSelector) *metav1.LabelSelector {
+	var newlbls = &metav1.LabelSelector{
+		MatchLabels: map[string]string{},
+	}
+	for key, val := range lbls.MatchLabels {
+		newlbls.MatchLabels[key] = s.sanitiseValue(val)
+	}
+	for _, exp := range lbls.MatchExpressions {
+		var oldval string
+		var newValues []string
+		// there can be empty values for cases when
+		// operator is 'Exists' or 'DoesNotExist'
+		if len(exp.Values) > 0 {
+			// field selector expects a single value
+			oldval = exp.Values[0]
+			newVal := s.sanitiseValue(oldval)
+			newValues = append(newValues, newVal)
+		} else {
+			newValues = nil
+		}
+		newlbls.MatchExpressions = append(
+			newlbls.MatchExpressions,
+			metav1.LabelSelectorRequirement{
+				Key:      exp.Key,      // remains same
+				Operator: exp.Operator, // remains same
+				Values:   newValues,
+			},
+		)
+	}
+	return newlbls
+}
+
+func (s *FieldSelection) init(lbls *metav1.LabelSelector) {
+	for key := range lbls.MatchLabels {
+		if key == "" {
+			s.err = errors.Errorf(
+				"Init failed: Missing field key: %+v",
+				lbls.MatchLabels,
+			)
+			return
+		}
+		s.fieldKeys = append(s.fieldKeys, key)
+	}
+	for _, exp := range lbls.MatchExpressions {
+		if exp.Key == "" {
+			s.err =
+				errors.Errorf(
+					"Init failed: Missing field expression key: %+v",
+					exp,
+				)
+			return
+		}
+		s.fieldKeys = append(s.fieldKeys, exp.Key)
+	}
+	// instantiate the labels.Selector
+	s.selector, s.err = metav1.LabelSelectorAsSelector(lbls)
+}
+
+// NewFieldSelector returns a new instance of FieldSelection
+func NewFieldSelector(lbls *metav1.LabelSelector) *FieldSelection {
+	s := &FieldSelection{}
+	newlbls := s.sanitiseLabels(lbls)
+	s.init(newlbls)
+	return s
+}
+
+// Match returns true if the given target matches the field
+// selection terms
+func (s *FieldSelection) Match(target *unstructured.Unstructured) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	// build the target labels
+	targetLbls := make(map[string]string)
+	for _, key := range s.fieldKeys {
+		// we expect the key represents a path to some nested
+		// field path in the structure
+		fields := strings.Split(key, ".")
+		val, found, err := unstructured.NestedString(target.Object, fields...)
+		if err != nil {
+			return false,
+				errors.Wrapf(
+					err,
+					"Match failed for key %s: %q / %q",
+					key,
+					target.GetNamespace(),
+					target.GetName(),
+				)
+		}
+		if !found {
+			// continue by ignoring this key since value is not found
+			//
+			// NOTE:
+			// 	This is helpful for cases where match is being
+			// made from 'Exists' or 'DoesNotExist' operator
+			continue
+		}
+		newVal := s.sanitiseValue(val)
+		targetLbls[key] = newVal
+	}
+	// at this point field expressions are made same as label expressions
+	return s.selector.Matches(labels.Set(targetLbls)), nil
+}

--- a/controller/common/selector/field_test.go
+++ b/controller/common/selector/field_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selector
+
+// TODO

--- a/controller/common/selector/slice.go
+++ b/controller/common/selector/slice.go
@@ -51,7 +51,7 @@ func (s KeyToSlice) Has(key string) bool {
 // words it returns if the match succeeded or failed for a slice
 // expression.
 //
-// This should be initialized via NewSliceSelectorMatcher
+// This should be initialized via NewSliceMatcher
 // constructor for creating a valid matcher instance.
 type SliceMatcher struct {
 	// key is the label key that the selector applies to.
@@ -84,7 +84,9 @@ func (r SliceMatcher) String() string {
 //
 // NOTE:
 // 	The empty string is a valid value in the input values set.
-func NewSliceMatcher(key string, op v1alpha1.SliceSelectorOperator, desiredValues []string) (*SliceMatcher, error) {
+func NewSliceMatcher(
+	key string, op v1alpha1.SliceSelectorOperator, desiredValues []string,
+) (*SliceMatcher, error) {
 	sm := &SliceMatcher{}
 	if key == "" {
 		return nil, errors.Errorf("%s: Key can't be empty", sm)
@@ -170,7 +172,7 @@ func (r *SliceMatcher) Match(observedKeySlice KeyToSlice) bool {
 // SliceSelector exposes match operation against string slices
 type SliceSelector struct {
 	// List of matchers that makes this slice selector instance.
-	// The results of these matchers are ANDed to form the final
+	// The results of these matchers are **ANDed** to form the final
 	// evaluation.
 	matchers []SliceMatcher
 

--- a/controller/common/selector/util.go
+++ b/controller/common/selector/util.go
@@ -26,7 +26,9 @@ import (
 // validateLabelKey validates if the given key is valid
 func validateLabelKey(key string) error {
 	if errs := validation.IsQualifiedName(key); len(errs) != 0 {
-		return errors.Errorf("Invalid label key %q: %s", key, strings.Join(errs, "; "))
+		return errors.Errorf(
+			"Invalid label key %q: [%s]", key, strings.Join(errs, "; "),
+		)
 	}
 	return nil
 }
@@ -35,7 +37,7 @@ func validateLabelKey(key string) error {
 func validateLabelValue(key, value string) error {
 	if errs := validation.IsValidLabelValue(value); len(errs) != 0 {
 		return errors.Errorf(
-			"Invalid label value %q at key %q: %s", value, key, strings.Join(errs, "; "),
+			"Invalid label value %q at key %q: [%s]", value, key, strings.Join(errs, "; "),
 		)
 	}
 	return nil

--- a/controller/common/selector/util_test.go
+++ b/controller/common/selector/util_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selector
+
+import "testing"
+
+func TestValidateLabelKey(t *testing.T) {
+	var tests = map[string]struct {
+		key   string
+		isErr bool
+	}{
+		"simple key": {
+			key:   "app",
+			isErr: false,
+		},
+		"dns key": {
+			key:   "app.mayadata.io/name",
+			isErr: false,
+		},
+		"hyphen in key": {
+			key:   "app-mayadata-io/name",
+			isErr: false,
+		},
+		"space in key": {
+			key:   "app mayadata io/name",
+			isErr: true,
+		},
+		"key starts with number": {
+			key:   "101.app.mayadata.io/name",
+			isErr: false,
+		},
+		"key ends with uid format": {
+			key:   "uid.app.mayadata.io/101211-a23dda-010101-zd2we1",
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			err := validateLabelKey(mock.key)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}
+
+func TestValidateLabelValue(t *testing.T) {
+	var tests = map[string]struct {
+		key   string
+		value string
+		isErr bool
+	}{
+		"simple value": {
+			key:   "simple",
+			value: "cstor",
+			isErr: false,
+		},
+		"value with hyphen": {
+			key:   "hyphen",
+			value: "my-cstor",
+			isErr: false,
+		},
+		"value with dots": {
+			key:   "dots",
+			value: "my.cstor.org",
+			isErr: false,
+		},
+		"value with forward slash": {
+			key:   "fwd-slash",
+			value: "my/cstor",
+			isErr: true,
+		},
+		"value with spaces": {
+			key:   "spaces",
+			value: "my cstor",
+			isErr: true,
+		},
+		"value with curly braces": {
+			key:   "curly-braces",
+			value: `{"my": "cstor"}`,
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			err := validateLabelValue(mock.key, mock.value)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -65,7 +65,7 @@ type parentController struct {
 	queue          workqueue.RateLimitingInterface
 
 	updateStrategy updateStrategyMap
-	childInformers common.ResourceInformerRegistryByVR
+	childInformers common.ResourceInformerRegistrar
 
 	finalizer *finalizer.Finalizer
 }
@@ -108,7 +108,7 @@ func newParentController(
 	}
 
 	// Create informers for all child resources.
-	childInformers := make(common.ResourceInformerRegistryByVR)
+	childInformers := make(common.ResourceInformerRegistrar)
 	defer func() {
 		if newErr != nil {
 			// If newParentController fails, Close() any informers we created
@@ -841,7 +841,7 @@ func (pc *parentController) claimChildren(
 		}
 
 		// Always include the requested groups, even if there are no entries.
-		childMap.InitGroupByVK(child.APIVersion, childClient.Kind)
+		childMap.Init(child.APIVersion, childClient.Kind)
 
 		// Handle orphan/adopt and filter by owner+selector.
 		crm := dynamiccontrollerref.NewUnstructClaimManager(

--- a/controller/decorator/controller.go
+++ b/controller/decorator/controller.go
@@ -60,7 +60,7 @@ type decoratorController struct {
 	resourceManager *dynamicdiscovery.APIResourceManager
 
 	// hold the parent kinds
-	parentKinds common.ResourceRegistryByGK
+	parentKinds common.ResourceRegistrar
 
 	// selector options to filter the parent
 	parentSelector *decoratorSelector
@@ -83,8 +83,8 @@ type decoratorController struct {
 	// the watched resource i.e. parent & to list the attachments
 	// i.e. children from the cache thereby reducing the pressure
 	// on kube api server
-	parentInformers common.ResourceInformerRegistryByVR
-	childInformers  common.ResourceInformerRegistryByVR
+	parentInformers common.ResourceInformerRegistrar
+	childInformers  common.ResourceInformerRegistrar
 
 	// instance that deals with this controller's finalizer
 	// if any
@@ -106,9 +106,9 @@ func newDecoratorController(
 		resourceManager: resourceMgr,
 		dynCliSet:       dynCliSet,
 
-		parentKinds:     make(common.ResourceRegistryByGK),
-		parentInformers: make(common.ResourceInformerRegistryByVR),
-		childInformers:  make(common.ResourceInformerRegistryByVR),
+		parentKinds:     make(common.ResourceRegistrar),
+		parentInformers: make(common.ResourceInformerRegistrar),
+		childInformers:  make(common.ResourceInformerRegistrar),
 
 		queue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.DefaultControllerRateLimiter(),
@@ -774,7 +774,7 @@ func (c *decoratorController) getChildren(
 				child.APIVersion,
 			)
 		}
-		childMap.InitGroupByVK(child.APIVersion, resource.Kind)
+		childMap.Init(child.APIVersion, resource.Kind)
 
 		// Take only the objects that belong to this parent,
 		// and that were created by this decorator.

--- a/controller/generic/controller_test.go
+++ b/controller/generic/controller_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	k8s "openebs.io/metac/third_party/kubernetes"
+)
+
+func TestUpdateStringMap(t *testing.T) {
+	var tests = map[string]struct {
+		dest     map[string]string
+		updates  map[string]*string
+		isChange bool
+		expect   map[string]string
+	}{
+		"nil dest & nil updates": {},
+		"nil dest & not nil updates": {
+			updates: map[string]*string{
+				"hi": k8s.StringPtr("hello"),
+			},
+			isChange: false,
+			expect: map[string]string{
+				"hi": "hello",
+			},
+		},
+		"dest & nil updates": {
+			dest: map[string]string{
+				"hi": "hello",
+			},
+			isChange: false,
+			expect: map[string]string{
+				"hi": "hello",
+			},
+		},
+		"just change": {
+			dest: map[string]string{
+				"hi": "hello",
+			},
+			updates: map[string]*string{
+				"hi": k8s.StringPtr("there"),
+			},
+			isChange: true,
+			expect: map[string]string{
+				"hi": "there",
+			},
+		},
+		"remove existing": {
+			dest: map[string]string{
+				"hi": "hello",
+			},
+			updates: map[string]*string{
+				"hi": nil,
+			},
+			isChange: true,
+			expect:   map[string]string{},
+		},
+		"remove everything": {
+			dest: map[string]string{
+				"hi":       "hello",
+				"namaskar": "all",
+			},
+			updates: map[string]*string{
+				"hi":       nil,
+				"namaskar": nil,
+			},
+			isChange: true,
+			expect:   map[string]string{},
+		},
+		"remove existing & new addition": {
+			dest: map[string]string{
+				"hi": "hello",
+			},
+			updates: map[string]*string{
+				"hi":       nil,
+				"namaskar": k8s.StringPtr("all"),
+			},
+			isChange: true,
+			expect: map[string]string{
+				"namaskar": "all",
+			},
+		},
+		"keep existing & new addition": {
+			dest: map[string]string{
+				"hi": "hello",
+			},
+			updates: map[string]*string{
+				"namaskar": k8s.StringPtr("all"),
+			},
+			isChange: true,
+			expect: map[string]string{
+				"hi":       "hello",
+				"namaskar": "all",
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			got := updateStringMap(mock.dest, mock.updates)
+			if mock.isChange != got {
+				t.Fatalf(
+					"Expected change %t got %t",
+					mock.isChange,
+					got,
+				)
+			}
+			if mock.dest == nil {
+				return
+			}
+			if len(mock.expect) != len(mock.dest) {
+				t.Fatalf(
+					"Expected dest count %d got %d",
+					len(mock.expect),
+					len(mock.dest),
+				)
+			}
+			for ek, ev := range mock.expect {
+				if mock.dest[ek] != ev {
+					t.Fatalf(
+						"Expected %s for key %s got %s",
+						ev,
+						ek,
+						mock.dest[ek],
+					)
+				}
+			}
+		})
+	}
+}

--- a/controller/generic/metacontroller_test.go
+++ b/controller/generic/metacontroller_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+)
+
+func TestNewConfigMetaController(t *testing.T) {
+	var tests = map[string]struct {
+		options []ConfigMetaControllerOption
+		isErr   bool
+	}{
+		"no options": {
+			isErr: true,
+		},
+		"with invalid config path": {
+			options: []ConfigMetaControllerOption{
+				func(ctl *ConfigMetaController) (err error) {
+					ctl.ConfigPath = "/etc/config/metac/"
+					return
+				},
+			},
+			isErr: true,
+		},
+		"with testdata as config path": {
+			options: []ConfigMetaControllerOption{
+				func(ctl *ConfigMetaController) (err error) {
+					ctl.ConfigPath = "testdata/"
+					return
+				},
+			},
+			isErr: false,
+		},
+		"with config loader func": {
+			options: []ConfigMetaControllerOption{
+				func(ctl *ConfigMetaController) (err error) {
+					ctl.ConfigLoadFn = func() ([]*v1alpha1.GenericController, error) {
+						return nil, nil
+					}
+					return
+				},
+			},
+			isErr: false,
+		},
+		"with erroring config loader func": {
+			options: []ConfigMetaControllerOption{
+				func(ctl *ConfigMetaController) (err error) {
+					ctl.ConfigLoadFn = func() ([]*v1alpha1.GenericController, error) {
+						return nil, errors.Errorf("Err")
+					}
+					return
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			_, err := NewConfigMetaController(
+				nil,
+				nil,
+				nil,
+				0,
+				mock.options...,
+			)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}
+
+func TestConfigMetaControllerIsDuplicateConfig(t *testing.T) {
+	var tests = map[string]struct {
+		Controller *ConfigMetaController
+		isErr      bool
+	}{
+		"nil configs": {
+			Controller: &ConfigMetaController{},
+			isErr:      false,
+		},
+		"empty configs": {
+			Controller: &ConfigMetaController{
+				Configs: []*v1alpha1.GenericController{},
+			},
+			isErr: false,
+		},
+		"1 config": {
+			Controller: &ConfigMetaController{
+				Configs: []*v1alpha1.GenericController{
+					&v1alpha1.GenericController{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"duplicate configs": {
+			Controller: &ConfigMetaController{
+				Configs: []*v1alpha1.GenericController{
+					&v1alpha1.GenericController{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+					&v1alpha1.GenericController{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			ctl := mock.Controller
+			ctl.isDuplicateConfig()
+			if mock.isErr && ctl.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && ctl.err != nil {
+				t.Fatalf("Expected no error got [%+v]", ctl.err)
+			}
+		})
+	}
+}
+
+func TestConfigMetaControllerWait(t *testing.T) {
+	var tests = map[string]struct {
+		controller *ConfigMetaController
+		condition  func() (bool, error)
+		isErr      bool
+	}{
+		"cond returns error": {
+			controller: &ConfigMetaController{
+				WaitIntervalForCondition: 1 * time.Second,
+				WaitTimeoutForCondition:  5 * time.Second,
+			},
+			condition: func() (bool, error) {
+				return false, errors.Errorf("Err")
+			},
+			isErr: true,
+		},
+		"cond returns true": {
+			controller: &ConfigMetaController{
+				WaitIntervalForCondition: 1 * time.Second,
+				WaitTimeoutForCondition:  5 * time.Second,
+			},
+			condition: func() (bool, error) {
+				return true, nil
+			},
+			isErr: false,
+		},
+		"cond returns false": {
+			controller: &ConfigMetaController{
+				WaitIntervalForCondition: 1 * time.Second,
+				WaitTimeoutForCondition:  5 * time.Second,
+			},
+			condition: func() (bool, error) {
+				return false, nil
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			ctl := mock.controller
+			err := ctl.wait(mock.condition)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}

--- a/controller/generic/selector.go
+++ b/controller/generic/selector.go
@@ -25,156 +25,300 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"openebs.io/metac/apis/metacontroller/v1alpha1"
-	"openebs.io/metac/controller/common"
+	"openebs.io/metac/controller/common/selector"
 	dynamicdiscovery "openebs.io/metac/dynamic/discovery"
 )
 
-// Selector is the placeholder to store various selection criteria
-// It is a single structure that supports multiple selector strategies
+// makeSelectorKeyFromAVK returns a formatted string suitable
+// to be used as a key of form 'kind.apiVersion'
 //
-// TODO (@amitkumardas) Check if this can be a common package
-type Selector struct {
-	nameSelectors       NameSelectorsByGK
-	labelSelectors      LabelSelectorsByGK
-	annotationSelectors AnnotationSelectorsByGK
+// The returned key is based on a combination of api version & kind
+func makeSelectorKeyFromAVK(apiVersion, kind string) string {
+	return fmt.Sprintf("%s.%s", kind, apiVersion)
 }
 
-// NameSelectorsByGK acts as the registrar of NameSelectors anchored by
-// apiversion and kind
-type NameSelectorsByGK map[string]v1alpha1.NameSelector
+// NameSelectorRegistrar acts as the registrar of NameSelectors
+// anchored by apiversion and kind
+type NameSelectorRegistrar map[string]v1alpha1.NameSelector
 
-// Set registers the given NameSelector based on the given version
-// and kind
-func (m NameSelectorsByGK) Set(group, kind string, selector v1alpha1.NameSelector) {
-	m[makeSelectorKeyFromGK(group, kind)] = selector
+// Set registers the given NameSelector based on the given
+// api version and kind
+func (m NameSelectorRegistrar) Set(apiVersion, kind string, selector v1alpha1.NameSelector) {
+	m[makeSelectorKeyFromAVK(apiVersion, kind)] = selector
 }
 
 // Get returns the NameSelector from the registrar based on the
-// given version and kind
-func (m NameSelectorsByGK) Get(group, kind string) v1alpha1.NameSelector {
-	return m[makeSelectorKeyFromGK(group, kind)]
+// given api version and kind
+func (m NameSelectorRegistrar) Get(apiVersion, kind string) v1alpha1.NameSelector {
+	return m[makeSelectorKeyFromAVK(apiVersion, kind)]
 }
 
-// LabelSelectorsByGK acts as the registrar of LabelSelectors anchored by
-// api group and kind
-type LabelSelectorsByGK map[string]labels.Selector
+// LabelSelectorRegistrar acts as the registrar of LabelSelectors
+// anchored by api version and kind
+type LabelSelectorRegistrar map[string]labels.Selector
 
 // Set registers the given LabelSelector based on the given version
 // and kind
-func (m LabelSelectorsByGK) Set(group, kind string, selector labels.Selector) {
-	m[makeSelectorKeyFromGK(group, kind)] = selector
+func (m LabelSelectorRegistrar) Set(apiVersion, kind string, selector labels.Selector) {
+	m[makeSelectorKeyFromAVK(apiVersion, kind)] = selector
 }
 
 // Get returns the LabelSelector from the registrar based on the
 // given version and kind
-func (m LabelSelectorsByGK) Get(group, kind string) labels.Selector {
-	return m[makeSelectorKeyFromGK(group, kind)]
+func (m LabelSelectorRegistrar) Get(apiVersion, kind string) labels.Selector {
+	return m[makeSelectorKeyFromAVK(apiVersion, kind)]
 }
 
-// AnnotationSelectorsByGK acts as the registrar of AnnotationSelectors
-// anchored by api group and kind
-type AnnotationSelectorsByGK map[string]labels.Selector
+// AnnotationSelectorRegistrar acts as the registrar of
+// AnnotationSelectors anchored by api version and kind
+type AnnotationSelectorRegistrar map[string]labels.Selector
 
-// Set registers the given AnnotationSelector based on the given version
-// and kind
-func (m AnnotationSelectorsByGK) Set(group, kind string, selector labels.Selector) {
-	m[makeSelectorKeyFromGK(group, kind)] = selector
+// Set registers the given AnnotationSelector based on the
+// given api version and kind
+func (m AnnotationSelectorRegistrar) Set(apiVersion, kind string, selector labels.Selector) {
+	m[makeSelectorKeyFromAVK(apiVersion, kind)] = selector
 }
 
-// Get returns the AnnotationSelector from the registrar based on the
-// given version and resource
-func (m AnnotationSelectorsByGK) Get(group, kind string) labels.Selector {
-	return m[makeSelectorKeyFromGK(group, kind)]
+// Get returns the AnnotationSelector from the registrar
+// based on the given version and resource
+func (m AnnotationSelectorRegistrar) Get(apiVersion, kind string) labels.Selector {
+	return m[makeSelectorKeyFromAVK(apiVersion, kind)]
 }
 
-// SelectorOption is a typed function used to build
-// an instance of selector
-//
-// This pattern of building an instance is known as
-// "functional options" pattern
-type SelectorOption func(*Selector) error
+// AdvancedSelectorRegistrar acts as the registrar of
+// selector.Evaluation anchored by api version and kind
+type AdvancedSelectorRegistrar map[string]selector.Evaluation
 
-// FromGCtlResourceSelectRequirements builds the Selector instance
-// based on GenericControllerResource's select requirements
-func FromGCtlResourceSelectRequirements(
-	resourceMgr *dynamicdiscovery.APIResourceManager,
-	gctlResource v1alpha1.GenericControllerResource,
-) SelectorOption {
-	return func(s *Selector) error {
-		var err error
+// Set registers the given selector.Evaluation based on the
+// given api version and kind
+func (m AdvancedSelectorRegistrar) Set(apiVersion, kind string, selector selector.Evaluation) {
+	m[makeSelectorKeyFromAVK(apiVersion, kind)] = selector
+}
 
-		if resourceMgr == nil {
-			return errors.Errorf("Selector failed: Nil resource manager")
+// Get returns the selector.Evaluation from the registrar
+// based on the given version and resource
+func (m AdvancedSelectorRegistrar) Get(apiVersion, kind string) selector.Evaluation {
+	return m[makeSelectorKeyFromAVK(apiVersion, kind)]
+}
+
+// Selection holds various select strategies
+type Selection struct {
+	nameSelectorReg       NameSelectorRegistrar
+	labelSelectorReg      LabelSelectorRegistrar
+	annotationSelectorReg AnnotationSelectorRegistrar
+	advancedSelectorReg   AdvancedSelectorRegistrar
+}
+
+// isDuplicateResource returns true if the given resource
+// is present in the selectors already
+func (s *Selection) isDuplicateResource(object *dynamicdiscovery.APIResource) bool {
+	// Any of the selectors can be used. We are using
+	// nameSelectors
+	for avk := range s.nameSelectorReg {
+		if avk == makeSelectorKeyFromAVK(object.APIVersion, object.Kind) {
+			return true
 		}
+	}
+	return false
+}
 
-		// fetch the resource from the discovered set
-		gctlResObj := resourceMgr.GetByResource(gctlResource.APIVersion, gctlResource.Resource)
-		if gctlResObj == nil {
-			return errors.Errorf(
-				"Selector failed: Can't find resource %s/%s",
-				gctlResource.APIVersion, gctlResource.Resource,
+func (s *Selection) setLabelSelectorOrEverything(
+	gctlResource v1alpha1.GenericControllerResource,
+	apiResource *dynamicdiscovery.APIResource,
+) error {
+	var err error
+	// set label selector to pass always
+	lblSelector := labels.Everything()
+	// Convert resource's label selector to labels.Selector
+	if gctlResource.LabelSelector != nil {
+		lblSelector, err =
+			metav1.LabelSelectorAsSelector(gctlResource.LabelSelector)
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"Label selector failed: %q: Version %q",
+				gctlResource.Resource,
+				gctlResource.APIVersion,
 			)
 		}
-
-		lblSel := labels.Everything()
-		// Convert the label selector to the internal form.
-		if gctlResource.LabelSelector != nil {
-			lblSel, err = metav1.LabelSelectorAsSelector(gctlResource.LabelSelector)
-			if err != nil {
-				return errors.Wrapf(
-					err, "Label selector for %s/%s failed",
-					gctlResource.APIVersion, gctlResource.Resource,
-				)
-			}
-		}
-		s.labelSelectors.Set(gctlResObj.Group, gctlResObj.Kind, lblSel)
-
-		annSel := labels.Everything()
-		// Convert the annotation selector to a label selector, then to
-		// internal form.
-		if gctlResource.AnnotationSelector != nil {
-			labelSelector := &metav1.LabelSelector{
-				MatchLabels:      gctlResource.AnnotationSelector.MatchAnnotations,
-				MatchExpressions: gctlResource.AnnotationSelector.MatchExpressions,
-			}
-			annSel, err = metav1.LabelSelectorAsSelector(labelSelector)
-			if err != nil {
-				return errors.Wrapf(
-					err, "Annotation selector for %s/%s failed",
-					gctlResource.APIVersion, gctlResource.Resource,
-				)
-			}
-		}
-		s.annotationSelectors.Set(gctlResObj.Group, gctlResObj.Kind, annSel)
-
-		// Set NameSelector to everything if it is empty
-		//
-		// NOTE:
-		// 	Empty nameselector evaluates to true for any names
-		nameSel := gctlResource.NameSelector
-		if nameSel == nil {
-			nameSel = []string{}
-		}
-		s.nameSelectors.Set(gctlResObj.Group, gctlResObj.Kind, nameSel)
-
-		return nil
 	}
+	s.labelSelectorReg.Set(
+		apiResource.APIVersion,
+		apiResource.Kind,
+		lblSelector,
+	)
+	return nil
 }
 
-// NewSelector returns a new instance of Selector
-func NewSelector(options ...SelectorOption) (*Selector, error) {
-	s := &Selector{}
+func (s *Selection) setAnnotationSelectorOrEverything(
+	gctlResource v1alpha1.GenericControllerResource,
+	apiResource *dynamicdiscovery.APIResource,
+) error {
+	var err error
+	// set annotation selector to pass always
+	annSelector := labels.Everything()
+	// convert annotation selector to
+	// 1/ api labels selector, & then to
+	// 2/ labels.Selector
+	if gctlResource.AnnotationSelector != nil {
+		lbls := &metav1.LabelSelector{
+			MatchLabels:      gctlResource.AnnotationSelector.MatchAnnotations,
+			MatchExpressions: gctlResource.AnnotationSelector.MatchExpressions,
+		}
+		annSelector, err = metav1.LabelSelectorAsSelector(lbls)
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				"Annotation selector failed: %q: Version %q",
+				gctlResource.Resource,
+				gctlResource.APIVersion,
+			)
+		}
+	}
+	s.annotationSelectorReg.Set(
+		apiResource.APIVersion,
+		apiResource.Kind,
+		annSelector,
+	)
+	return nil
+}
 
-	// init all the selector strategies
-	//
+func (s *Selection) setNameSelectorOrEverything(
+	gctlResource v1alpha1.GenericControllerResource,
+	apiResource *dynamicdiscovery.APIResource,
+) error {
+	nameSelector := gctlResource.NameSelector
+	if nameSelector == nil {
+		// empty nameselector passes always i.e. evaluates to
+		// true for any given name
+		nameSelector = []string{}
+	}
+	s.nameSelectorReg.Set(
+		apiResource.APIVersion,
+		apiResource.Kind,
+		nameSelector,
+	)
+	return nil
+}
+
+func (s *Selection) setAdvancedSelectorOrEverything(
+	gctlResource v1alpha1.GenericControllerResource,
+	apiResource *dynamicdiscovery.APIResource,
+) error {
+	var terms []*v1alpha1.SelectorTerm
+	if gctlResource.AdvancedSelector != nil {
+		terms = gctlResource.AdvancedSelector.SelectorTerms
+	}
 	// NOTE:
-	// 	Ensure that each option point to different resource kind
-	s.nameSelectors = NameSelectorsByGK(make(map[string]v1alpha1.NameSelector))
-	s.labelSelectors = LabelSelectorsByGK(make(map[string]labels.Selector))
-	s.annotationSelectors = AnnotationSelectorsByGK(make(map[string]labels.Selector))
+	//	resource selector will pass always if there are no terms
+	advancedSelector := selector.Evaluation{
+		Terms: terms,
+	}
+	s.advancedSelectorReg.Set(
+		apiResource.APIVersion,
+		apiResource.Kind,
+		advancedSelector,
+	)
+	return nil
+}
 
-	for _, o := range options {
-		err := o(s)
+// register registers the Selection instance with various
+// selectors based on the provided GenericControllerResource
+func (s *Selection) register(
+	discoveryMgr *dynamicdiscovery.APIResourceManager,
+	gctlResource v1alpha1.GenericControllerResource,
+) error {
+	var err error
+	if discoveryMgr == nil {
+		return errors.Errorf(
+			"Selector init failed: Nil api resource discovery manager",
+		)
+	}
+	if gctlResource.APIVersion == "" {
+		return errors.Errorf(
+			"Selector init failed: Missing gctl resource api version",
+		)
+	}
+	if gctlResource.Resource == "" {
+		return errors.Errorf(
+			"Selector init failed: Missing gctl resource name",
+		)
+	}
+	// fetch the resource from the discovered set
+	apiResource := discoveryMgr.GetByResource(
+		gctlResource.APIVersion,
+		gctlResource.Resource,
+	)
+	if apiResource == nil {
+		return errors.Errorf(
+			"Selector init failed: Can't find %q: Version %q",
+			gctlResource.Resource,
+			gctlResource.APIVersion,
+		)
+	}
+	if s.isDuplicateResource(apiResource) {
+		return errors.Errorf(
+			"Selector init failed: Duplicate resource %q: Version %q",
+			gctlResource.Resource,
+			gctlResource.APIVersion,
+		)
+	}
+	// Set the Selectors
+	var setters = []func(
+		v1alpha1.GenericControllerResource,
+		*dynamicdiscovery.APIResource,
+	) error{
+		s.setLabelSelectorOrEverything,
+		s.setAnnotationSelectorOrEverything,
+		s.setNameSelectorOrEverything,
+		s.setAdvancedSelectorOrEverything,
+	}
+	for _, setter := range setters {
+		err = setter(gctlResource, apiResource)
+		if err != nil {
+			return errors.Wrapf(err, "Selector init failed")
+		}
+	}
+	return nil
+}
+
+// init all the selector strategies
+func (s *Selection) init() {
+	s.nameSelectorReg = NameSelectorRegistrar(make(map[string]v1alpha1.NameSelector))
+	s.labelSelectorReg = LabelSelectorRegistrar(make(map[string]labels.Selector))
+	s.annotationSelectorReg = AnnotationSelectorRegistrar(make(map[string]labels.Selector))
+	s.advancedSelectorReg = AdvancedSelectorRegistrar(make(map[string]selector.Evaluation))
+}
+
+// NewSelectorForWatch returns a new instance of Selection
+// based on watch
+func NewSelectorForWatch(
+	discoveryMgr *dynamicdiscovery.APIResourceManager,
+	watch v1alpha1.GenericControllerResource,
+) (*Selection, error) {
+	s := &Selection{}
+	s.init()
+	err := s.register(discoveryMgr, watch)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// NewSelectorForAttachments returns a new instance of Selection
+// based on the attachments
+func NewSelectorForAttachments(
+	discoveryMgr *dynamicdiscovery.APIResourceManager,
+	attachments []v1alpha1.GenericControllerAttachment,
+) (*Selection, error) {
+	s := &Selection{}
+	s.init()
+	for _, attachment := range attachments {
+		// register each attachment
+		err := s.register(
+			discoveryMgr,
+			attachment.GenericControllerResource,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -182,27 +326,94 @@ func NewSelector(options ...SelectorOption) (*Selector, error) {
 	return s, nil
 }
 
-// Matches returns true if the provided unstruct instance match this
-// selector settings
-func (s *Selector) Matches(obj *unstructured.Unstructured) bool {
-	// Look up the label and annotation selectors for this object.
-	// Use only Group and Kind. Ignore Version.
-	apiGroup, _ := common.ParseAPIVersionToGroupVersion(obj.GetAPIVersion())
-
-	nameSelector := s.nameSelectors.Get(apiGroup, obj.GetKind())
-	labelSelector := s.labelSelectors.Get(apiGroup, obj.GetKind())
-	annotationSelector := s.annotationSelectors.Get(apiGroup, obj.GetKind())
-
-	// It must match all selectors.
+// MatchLAN returns true if the provided instance matches following
+// selector settings:
+// - LabelSelector (L)
+// - AnnotationSelector (A)
+// - NameSelector (N)
+func (s *Selection) MatchLAN(obj *unstructured.Unstructured) (bool, error) {
+	if obj == nil {
+		return false, errors.Errorf("Match failed: Nil target")
+	}
+	// Fetch appropriate selectors based on the given object's
+	// api version & kind. Run matches from the extracted selectors
+	nameSelector := s.nameSelectorReg.Get(obj.GetAPIVersion(), obj.GetKind())
+	labelSelector := s.labelSelectorReg.Get(obj.GetAPIVersion(), obj.GetKind())
+	annotationSelector := s.annotationSelectorReg.Get(obj.GetAPIVersion(), obj.GetKind())
+	// All selector matches are **AND-ed**
 	return labelSelector.Matches(labels.Set(obj.GetLabels())) &&
 		annotationSelector.Matches(labels.Set(obj.GetAnnotations())) &&
-		nameSelector.ContainsOrTrue(obj.GetName())
+		nameSelector.ContainsOrTrue(obj.GetName()), nil
 }
 
-// makeSelectorKeyFromGK returns a formatted string suitable to be
-// used as a key of form 'kind.apigroup'
+// Match returns true if the provided instance matches following
+// selector settings:
 //
-// The returned key is based on a combination of api group & kind
-func makeSelectorKeyFromGK(apiGroup, kind string) string {
-	return fmt.Sprintf("%s.%s", kind, apiGroup)
+// - NameSelector
+// - LabelSelector
+// - AnnotationSelector
+// - AdvancedSelector (minus reference match)
+func (s *Selection) Match(obj *unstructured.Unstructured) (bool, error) {
+	// lanMatch refers to label, annotation & name selector
+	// based match result
+	lanMatch, err := s.MatchLAN(obj)
+	if err != nil {
+		return false, err
+	}
+	// fetch advanced selector based on attachment
+	// api version & kind
+	sel := s.advancedSelectorReg.Get(
+		obj.GetAPIVersion(),
+		obj.GetKind(),
+	)
+	// make a copy
+	var newsel = selector.Evaluation{
+		Terms:  sel.Terms,
+		Target: obj,
+	}
+	advanceMatch, err := newsel.RunMatch()
+	if err != nil {
+		return false, err
+	}
+	// All selector matches are **AND-ed**
+	return lanMatch && advanceMatch, nil
+}
+
+// MatchAttachmentAgainstWatch returns true if the provided
+// attachment match this selector settings for the provided
+// watch
+//
+// Following selectors are executed:
+// - NameSelector
+// - LabelSelector
+// - AnnotationSelector
+// - AdvancedSelector (i.e. includes matching attachment against watch)
+func (s *Selection) MatchAttachmentAgainstWatch(
+	attachment *unstructured.Unstructured,
+	watch *unstructured.Unstructured,
+) (bool, error) {
+	// lanMatch refers to label, annotation & name selector
+	// based match result
+	lanMatch, err := s.MatchLAN(attachment)
+	if err != nil {
+		return false, err
+	}
+	// fetch advanced selector based on attachment
+	// api version & kind
+	sel := s.advancedSelectorReg.Get(
+		attachment.GetAPIVersion(),
+		attachment.GetKind(),
+	)
+	// make a copy
+	var newSel = selector.Evaluation{
+		Terms:     sel.Terms,
+		Target:    attachment,
+		Reference: watch,
+	}
+	advanceMatch, err := newSel.RunMatch()
+	if err != nil {
+		return false, err
+	}
+	// All selector matches are **AND-ed**
+	return lanMatch && advanceMatch, nil
 }

--- a/controller/generic/selector_test.go
+++ b/controller/generic/selector_test.go
@@ -1,0 +1,884 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"openebs.io/metac/apis/metacontroller/v1alpha1"
+	dynamicdiscovery "openebs.io/metac/dynamic/discovery"
+)
+
+func TestMakeSelectorKeyFromAVK(t *testing.T) {
+	var tests = map[string]struct {
+		apiVersion string
+		kind       string
+		expect     string
+	}{
+		"valid values": {
+			apiVersion: "v1",
+			kind:       "Pod",
+			expect:     "Pod.v1",
+		},
+		"missing apiversion": {
+			apiVersion: "",
+			kind:       "Pod",
+			expect:     "Pod.",
+		},
+		"missing kind": {
+			apiVersion: "v1",
+			kind:       "",
+			expect:     ".v1",
+		},
+		"missing both": {
+			apiVersion: "",
+			kind:       "",
+			expect:     ".",
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			got := makeSelectorKeyFromAVK(mock.apiVersion, mock.kind)
+			if got != mock.expect {
+				t.Fatalf("Expected %q got %q", mock.expect, got)
+			}
+		})
+	}
+}
+
+func TestSelectorMatchesLAN(t *testing.T) {
+	var tests = map[string]struct {
+		controllerResource v1alpha1.GenericControllerResource
+		apiResource        *dynamicdiscovery.APIResource
+		target             *unstructured.Unstructured
+		isMatch            bool
+		isMatchErr         bool
+		isErr              bool
+	}{
+		"empty controller resource": {
+			controllerResource: v1alpha1.GenericControllerResource{},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   true,
+		},
+		"no controller resource matchers": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"nil target": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app": "metac",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target:     nil,
+			isMatch:    false,
+			isMatchErr: true,
+			isErr:      false,
+		},
+		"nil api resource": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app": "metac",
+					},
+				},
+			},
+			apiResource: nil,
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   true,
+		},
+		"match annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app": "metac",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"match annotation expressions": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"metac"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"no match annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"apps": "metac",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match labels": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "metac",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"no match labels": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"apps": "metac",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match label expressions": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"metac"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "metac",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"match name": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"no match name": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Podie",
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match name && labels": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":        "metac",
+						"controller": "declarative",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"labels": map[string]interface{}{
+							"app":        "metac",
+							"controller": "declarative",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"match name && no match labels": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":  "metac",
+						"ctrl": "declarative",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"labels": map[string]interface{}{
+							"app":        "metac",
+							"controller": "declarative",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match name && annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":        "metac",
+						"controller": "declarative",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":        "metac",
+							"controller": "declarative",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"match name && no match annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":        "metac",
+							"controller": "declarative",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match name, labels && annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"metac"},
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "appie",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+					},
+					MatchLabels: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "appy",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"none"},
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"metac"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+						"labels": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+					},
+				},
+			},
+			isMatch: true,
+			isErr:   false,
+		},
+		"match name && labels && no match annotations": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"metac"},
+						},
+					},
+					MatchLabels: map[string]string{
+						"meta": "controller",
+					},
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"none"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+						"labels": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match name && annotations && no match labels": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"none"},
+						},
+					},
+					MatchLabels: map[string]string{
+						"meta": "controller",
+					},
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"none"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+						"labels": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+		"match labels && annotations && no match name": {
+			controllerResource: v1alpha1.GenericControllerResource{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: "v1",
+					Resource:   "pods",
+				},
+				NameSelector: v1alpha1.NameSelector([]string{"My-Pod-ies"}),
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"none"},
+						},
+					},
+					MatchLabels: map[string]string{
+						"meta": "controller",
+					},
+				},
+				AnnotationSelector: &v1alpha1.AnnotationSelector{
+					MatchAnnotations: map[string]string{
+						"app":  "metac",
+						"meta": "controller",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+						metav1.LabelSelectorRequirement{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"none"},
+						},
+					},
+				},
+			},
+			apiResource: &dynamicdiscovery.APIResource{
+				APIVersion: "v1",
+				APIResource: metav1.APIResource{
+					Kind: "Pod",
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "My-Pod",
+						"annotations": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+						"labels": map[string]interface{}{
+							"app":  "metac",
+							"meta": "controller",
+						},
+					},
+				},
+			},
+			isMatch: false,
+			isErr:   false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			mgr := &dynamicdiscovery.APIResourceManager{
+				GetByResourceFn: func(apiVer, resource string) *dynamicdiscovery.APIResource {
+					return mock.apiResource
+				},
+			}
+			s, err := NewSelectorForWatch(mgr, mock.controllerResource)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got nil")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if err == nil {
+				match, err := s.MatchLAN(mock.target)
+				if mock.isMatchErr && err == nil {
+					t.Fatalf("Expected match error got none")
+				}
+				if !mock.isMatchErr && err != nil {
+					t.Fatalf("Expected no match error got [%+v]", err)
+				}
+				if !mock.isMatchErr && match != mock.isMatch {
+					t.Fatalf("Expected match %t got %t", mock.isMatch, match)
+				}
+			}
+		})
+	}
+}

--- a/controller/generic/testdata/test_gctl.yaml
+++ b/controller/generic/testdata/test_gctl.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: set-status-on-cr
+spec:
+  watch:
+    apiVersion: examples.metac.io/v1
+    resource: coolnerds
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cool-nerd
+---

--- a/helm/metac/templates/crds.yaml
+++ b/helm/metac/templates/crds.yaml
@@ -41,8 +41,12 @@ spec:
               items:
                 properties:
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                   updateStrategy:
                     properties:
@@ -224,8 +228,12 @@ spec:
             parentResource:
               properties:
                 apiVersion:
+                  description: APIVersion is the combination of group & version of
+                    the resource
                   type: string
                 resource:
+                  description: Resource is the name of the resource. Its also the
+                    plural of Kind
                   type: string
                 revisionHistory:
                   properties:
@@ -371,8 +379,12 @@ spec:
               items:
                 properties:
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                   updateStrategy:
                     properties:
@@ -501,6 +513,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   labelSelector:
                     description: A label selector is a label query over a set of resources.
@@ -550,6 +564,8 @@ spec:
                         type: object
                     type: object
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                 required:
                 - apiVersion
@@ -632,102 +648,12 @@ spec:
                 description: GenericControllerAttachment represents a resources that
                   takes part in sync &/or finalize.
                 properties:
-                  annotationSelector:
-                    description: "Include the resource if annotation selector matches
-                      \n This is ANDed with other selectors if present"
-                    properties:
-                      matchAnnotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      matchExpressions:
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                    type: object
-                  apiVersion:
-                    type: string
-                  labelSelector:
-                    description: "Include the resource if label selector matches \n
-                      This is ANDed with other selectors if present"
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  nameSelector:
-                    description: "Include the resource if name selector matches \n
-                      This is ANDed with other selectors if present"
-                    items:
-                      type: string
-                    type: array
-                  resource:
-                    type: string
-                  resourceSelector:
+                  advancedSelector:
                     description: "Include the resource if resource selector matches
-                      \n This is ANDed with other selectors if present"
+                      \n This is ANDed with other selectors if present \n NOTE: \tThis
+                      is an advanced selector & can be used to perform matches on
+                      complex selection criterias against combinations of labels,
+                      annotations, name, namespace, target object, path & slice values."
                     properties:
                       selectorTerms:
                         description: A list of selector terms. This list of terms
@@ -992,6 +918,103 @@ spec:
                     required:
                     - selectorTerms
                     type: object
+                  annotationSelector:
+                    description: "Include the resource if annotation selector matches
+                      \n This is ANDed with other selectors if present"
+                    properties:
+                      matchAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      matchExpressions:
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
+                    type: string
+                  labelSelector:
+                    description: "Include the resource if label selector matches \n
+                      This is ANDed with other selectors if present"
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  nameSelector:
+                    description: "Include the resource if name selector matches \n
+                      This is ANDed with other selectors if present"
+                    items:
+                      type: string
+                    type: array
+                  resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
+                    type: string
                   updateStrategy:
                     description: UpdateStrategy to be used for the resource to take
                       into account the changes due to sync/finalize
@@ -1135,102 +1158,12 @@ spec:
                 actions i.e. 'create', 'update' or 'delete' of this resource will
                 trigger this GenericController's sync process.
               properties:
-                annotationSelector:
-                  description: "Include the resource if annotation selector matches
-                    \n This is ANDed with other selectors if present"
-                  properties:
-                    matchAnnotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    matchExpressions:
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                  type: object
-                apiVersion:
-                  type: string
-                labelSelector:
-                  description: "Include the resource if label selector matches \n
-                    This is ANDed with other selectors if present"
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                nameSelector:
-                  description: "Include the resource if name selector matches \n This
-                    is ANDed with other selectors if present"
-                  items:
-                    type: string
-                  type: array
-                resource:
-                  type: string
-                resourceSelector:
+                advancedSelector:
                   description: "Include the resource if resource selector matches
-                    \n This is ANDed with other selectors if present"
+                    \n This is ANDed with other selectors if present \n NOTE: \tThis
+                    is an advanced selector & can be used to perform matches on complex
+                    selection criterias against combinations of labels, annotations,
+                    name, namespace, target object, path & slice values."
                   properties:
                     selectorTerms:
                       description: A list of selector terms. This list of terms are
@@ -1492,6 +1425,103 @@ spec:
                   required:
                   - selectorTerms
                   type: object
+                annotationSelector:
+                  description: "Include the resource if annotation selector matches
+                    \n This is ANDed with other selectors if present"
+                  properties:
+                    matchAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    matchExpressions:
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                  type: object
+                apiVersion:
+                  description: APIVersion is the combination of group & version of
+                    the resource
+                  type: string
+                labelSelector:
+                  description: "Include the resource if label selector matches \n
+                    This is ANDed with other selectors if present"
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nameSelector:
+                  description: "Include the resource if name selector matches \n This
+                    is ANDed with other selectors if present"
+                  items:
+                    type: string
+                  type: array
+                resource:
+                  description: Resource is the name of the resource. Its also the
+                    plural of Kind
+                  type: string
               required:
               - apiVersion
               - resource

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -40,8 +40,12 @@ spec:
               items:
                 properties:
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                   updateStrategy:
                     properties:
@@ -223,8 +227,12 @@ spec:
             parentResource:
               properties:
                 apiVersion:
+                  description: APIVersion is the combination of group & version of
+                    the resource
                   type: string
                 resource:
+                  description: Resource is the name of the resource. Its also the
+                    plural of Kind
                   type: string
                 revisionHistory:
                   properties:
@@ -370,8 +378,12 @@ spec:
               items:
                 properties:
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                   updateStrategy:
                     properties:
@@ -500,6 +512,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
                     type: string
                   labelSelector:
                     description: A label selector is a label query over a set of resources.
@@ -549,6 +563,8 @@ spec:
                         type: object
                     type: object
                   resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
                     type: string
                 required:
                 - apiVersion
@@ -631,102 +647,12 @@ spec:
                 description: GenericControllerAttachment represents a resources that
                   takes part in sync &/or finalize.
                 properties:
-                  annotationSelector:
-                    description: "Include the resource if annotation selector matches
-                      \n This is ANDed with other selectors if present"
-                    properties:
-                      matchAnnotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      matchExpressions:
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                    type: object
-                  apiVersion:
-                    type: string
-                  labelSelector:
-                    description: "Include the resource if label selector matches \n
-                      This is ANDed with other selectors if present"
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  nameSelector:
-                    description: "Include the resource if name selector matches \n
-                      This is ANDed with other selectors if present"
-                    items:
-                      type: string
-                    type: array
-                  resource:
-                    type: string
-                  resourceSelector:
+                  advancedSelector:
                     description: "Include the resource if resource selector matches
-                      \n This is ANDed with other selectors if present"
+                      \n This is ANDed with other selectors if present \n NOTE: \tThis
+                      is an advanced selector & can be used to perform matches on
+                      complex selection criterias against combinations of labels,
+                      annotations, name, namespace, target object, path & slice values."
                     properties:
                       selectorTerms:
                         description: A list of selector terms. This list of terms
@@ -991,6 +917,103 @@ spec:
                     required:
                     - selectorTerms
                     type: object
+                  annotationSelector:
+                    description: "Include the resource if annotation selector matches
+                      \n This is ANDed with other selectors if present"
+                    properties:
+                      matchAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      matchExpressions:
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  apiVersion:
+                    description: APIVersion is the combination of group & version
+                      of the resource
+                    type: string
+                  labelSelector:
+                    description: "Include the resource if label selector matches \n
+                      This is ANDed with other selectors if present"
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  nameSelector:
+                    description: "Include the resource if name selector matches \n
+                      This is ANDed with other selectors if present"
+                    items:
+                      type: string
+                    type: array
+                  resource:
+                    description: Resource is the name of the resource. Its also the
+                      plural of Kind
+                    type: string
                   updateStrategy:
                     description: UpdateStrategy to be used for the resource to take
                       into account the changes due to sync/finalize
@@ -1134,102 +1157,12 @@ spec:
                 actions i.e. 'create', 'update' or 'delete' of this resource will
                 trigger this GenericController's sync process.
               properties:
-                annotationSelector:
-                  description: "Include the resource if annotation selector matches
-                    \n This is ANDed with other selectors if present"
-                  properties:
-                    matchAnnotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    matchExpressions:
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                  type: object
-                apiVersion:
-                  type: string
-                labelSelector:
-                  description: "Include the resource if label selector matches \n
-                    This is ANDed with other selectors if present"
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                nameSelector:
-                  description: "Include the resource if name selector matches \n This
-                    is ANDed with other selectors if present"
-                  items:
-                    type: string
-                  type: array
-                resource:
-                  type: string
-                resourceSelector:
+                advancedSelector:
                   description: "Include the resource if resource selector matches
-                    \n This is ANDed with other selectors if present"
+                    \n This is ANDed with other selectors if present \n NOTE: \tThis
+                    is an advanced selector & can be used to perform matches on complex
+                    selection criterias against combinations of labels, annotations,
+                    name, namespace, target object, path & slice values."
                   properties:
                     selectorTerms:
                       description: A list of selector terms. This list of terms are
@@ -1491,6 +1424,103 @@ spec:
                   required:
                   - selectorTerms
                   type: object
+                annotationSelector:
+                  description: "Include the resource if annotation selector matches
+                    \n This is ANDed with other selectors if present"
+                  properties:
+                    matchAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    matchExpressions:
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                  type: object
+                apiVersion:
+                  description: APIVersion is the combination of group & version of
+                    the resource
+                  type: string
+                labelSelector:
+                  description: "Include the resource if label selector matches \n
+                    This is ANDed with other selectors if present"
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nameSelector:
+                  description: "Include the resource if name selector matches \n This
+                    is ANDed with other selectors if present"
+                  items:
+                    type: string
+                  type: array
+                resource:
+                  description: Resource is the name of the resource. Its also the
+                    plural of Kind
+                  type: string
               required:
               - apiVersion
               - resource

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -190,7 +190,7 @@ func startCRDBasedMetaControllers(testRunFn func() int) error {
 		DiscoveryInterval: 500 * time.Millisecond,
 		InformerRelist:    30 * time.Minute,
 	}
-	crdServer := &server.CRDBasedServer{Server: mserver}
+	crdServer := &server.CRDServer{Server: mserver}
 	stopServer, err := crdServer.Start(5)
 	if err != nil {
 		return errors.Wrapf(err, "Can't start crd based metacontroller server")

--- a/test/integration/framework/metacontroller.go
+++ b/test/integration/framework/metacontroller.go
@@ -212,7 +212,7 @@ func (f *Fixture) CreateGenericControllerAsMetacConfig(
 }
 
 // StartMetacFromGenericControllerConfig starts Metac based
-// on the given config. It returns the stop function that 
+// on the given config. It returns the stop function that
 // should be invoked by the caller once caller's task is done.
 func (f *Fixture) StartMetacFromGenericControllerConfig(gctlAsConfigFn func() ([]*v1alpha1.GenericController, error)) (stop func()) {
 	var mserver = server.Server{
@@ -220,9 +220,9 @@ func (f *Fixture) StartMetacFromGenericControllerConfig(gctlAsConfigFn func() ([
 		DiscoveryInterval: 500 * time.Millisecond,
 		InformerRelist:    30 * time.Minute,
 	}
-	metacServer := &server.ConfigBasedServer{
-		Server:                      mserver,
-		GenericControllerAsConfigFn: gctlAsConfigFn,
+	metacServer := &server.ConfigServer{
+		Server:                        mserver,
+		GenericControllerConfigLoadFn: gctlAsConfigFn,
 	}
 	stopMetacServer, err := metacServer.Start(5)
 	if err != nil {


### PR DESCRIPTION
This commit adds advanced selector to GenericController. This enables controller developer to add selector to filter watch or attachments or both. Advanced selector enables one to match by `namespace`, `labels`, `annotations`, `finalizers`, any field in `spec`, any field in `status`. One can combine various select options and execute these options via `AND-ing` or `OR-ing` or a combination of both AND & OR.

_NOTE: It can match fields with []string datatype as its values as well._
_NOTE: Advanced selector can't match fields with datatypes other than string & []string._

This commit also marks a change to the log levels for GenericController. Since generic controller is mostly being used as a library in other binaries, it becomes essential to put controller logs at more verbose levels.

In addition, various unit test cases, rename related refactoring, and better comments have been added to make metac logic more readable & easy to contribute.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>