### PR TITLE
chore(semantic-release): #64 - Enable semantic release

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,58 @@
+---
+name: Test and Release (if on master)
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        test: ['unit-test', 'integration-test']
+    name: ${{ matrix.test }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: setup env
+        run: |
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.5
+      - run: make ${{ matrix.test }}
+  release:
+    name: Release
+    runs-on: ubuntu-18.04
+    needs: ['tests']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm install ci
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
+  release-docker:
+    name: Release docke rimage
+    runs-on: ubuntu-18.04
+    needs: ['tests']
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Deploy docker image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: quay.io/amitkumardas/metac
+          registry: quay.io
+          tag_with_ref: true
+          add_git_labels: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/hack/get-kube-binaries.sh
+++ b/hack/get-kube-binaries.sh
@@ -30,12 +30,12 @@ cd hack/bin
 # uncomment below for mandatory download
 #rm -f kubectl
 
-if ./kubectl version --client; then
+if [[ -f ./kubectl ]] && ./kubectl version --client; then
     echo ""
     echo "+++ Above kubectl was installed previously"
     echo ""
 else
-    wget "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kubectl"
+    wget -nv "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kubectl"
     chmod +x kubectl
 fi
 
@@ -44,12 +44,12 @@ fi
 # uncomment below for mandatory download
 #rm -f kube-apiserver
 
-if ./kube-apiserver --version; then
+if [[ -f ./kube-apiserver ]] && ./kube-apiserver --version; then
     echo ""
     echo "+++ Above kube-apiserver was installed previously"
     echo ""
 else
-    wget "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kube-apiserver"
+    wget -nv "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kube-apiserver"
     chmod +x kube-apiserver
 fi
 
@@ -57,7 +57,7 @@ fi
 # uncomment below for mandatory download
 #rm -f etcd
 
-if ./etcd --version; then
+if [[ -f ./etcd ]] && ./etcd --version; then
     echo ""
     echo "+++ Above etcd was installed previously"
     echo ""
@@ -65,7 +65,7 @@ else
     basename="etcd-${ETCD_VERSION}-linux-amd64"
     filename="${basename}.tar.gz"
     url="https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${filename}"
-    wget "${url}"
+    wget -nv "${url}"
     tar -zxf "${filename}"
     mv "${basename}/etcd" etcd
     rm -rf "${basename}" "${filename}"

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "branches": ["master"],
+  "plugins": [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/github']
+}


### PR DESCRIPTION
Configuration based on recipe  for https://github.com/marketplace/actions/action-for-semantic-release

Currently set to :
* branches - master and semantic-release (for testing)


Job output https://github.com/grzesuav/metac/actions/runs/57755684
* click on `Release` on the left
* you can expand to see `Release` in logs

I have triggered a release on my fork : 
https://github.com/grzesuav/metac/releases

# ~~PLEASE DO NOT MERGE~~