### PR TITLE
chore(examples): add hello-python example using CompositeController

### DIFF
--- a/examples/cctl/hello-python/controller.yaml
+++ b/examples/cctl/hello-python/controller.yaml
@@ -1,0 +1,18 @@
+apiVersion: metac.openebs.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: hello-controller
+spec:
+  generateSelector: true
+  parentResource:
+    apiVersion: example.com/v1
+    resource: helloworlds
+  childResources:
+  - apiVersion: v1
+    resource: pods
+    updateStrategy:
+      method: Recreate
+  hooks:
+    sync:
+      webhook:
+        url: http://hello-controller.hello/sync

--- a/examples/cctl/hello-python/crd.yaml
+++ b/examples/cctl/hello-python/crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: helloworlds.example.com
+spec:
+  group: example.com
+  version: v1
+  names:
+    kind: HelloWorld
+    plural: helloworlds
+    singular: helloworld
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/examples/cctl/hello-python/readme.md
+++ b/examples/cctl/hello-python/readme.md
@@ -1,5 +1,5 @@
 ## Example python Controller
-This example is taken from [metacontroller](https://metacontroller.app/guide/create/) doc. There is an issue in this example that leads to continuous reconciliations. When _'CompositeController'_ is used with the parent resource's status **undefined** as a sub-resource, then the reconciliation gets into an infinite loop. This happens since _'CompositeController'_ updates _'status.observedGeneration'_ with _'metadata.generation'_ as part of its reconciliation.
+If you are using _'CompositeController'_ one basic misconfiguration can lead the controller to continuous reconciliations. When _'CompositeController'_ is used with the parent resource's status **undefined** as a sub-resource, then the reconciliation gets into an infinite loop. This happens since _'CompositeController'_ updates _'status.observedGeneration'_ with _'metadata.generation'_ as part of its reconciliation.
 
 Following sums up the reconciliation logic when status is defined as a sub resource & vice-versa:
 
@@ -12,14 +12,6 @@ Following sums up the reconciliation logic when status is defined as a sub resou
     status: {}
 ```
 
-
-What changes you need to do? 
-
-You need to add below in your crd
-```yaml
-  subresources:
-    status: {}
-```
 ### Use
 ```yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -93,7 +85,7 @@ Check the log of the pod and try to create other helloworld cr or update any hel
 ### Cleanup
 ```bash
 kubectl delete helloworld -A --all
-kubectl ns hello
+kubectl delete ns hello
 kubectl delete -f controller.yaml
 kubectl delete -f crd.yaml
 ```

--- a/examples/cctl/hello-python/readme.md
+++ b/examples/cctl/hello-python/readme.md
@@ -1,0 +1,95 @@
+## Example python Controller
+This example is taken from [metacontroller](https://metacontroller.app/guide/create/) doc. There were some issue in this example if you are using `CompositeController` and status subresource is not enabled for parent resource then your controller will go into an infinite loop. For `CompositeController` it updates `status.observedGeneration` with `metadata.generation` for parent resource.
+
+This will be done in 2 ways -
+
+1. If status subresource is enabled for parent then it will patch the status with cr's status end point and  `metadata.generation` of parent will not change.
+2. If status subresource is not enabled for parent then it will update the full object. For that there will be a change in `metadata.generation` of parent. Which will invoke a reconciliation and that reconciliation will invoke `metadata.generation` update in parent. So it will be a contineous loop.
+
+
+What changes you need to do? 
+
+You need to add below in your crd
+```yaml
+  subresources:
+    status: {}
+```
+### Use
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: helloworlds.example.com
+spec:
+  group: example.com
+  version: v1
+  names:
+    kind: HelloWorld
+    plural: helloworlds
+    singular: helloworld
+  scope: Namespaced
+  subresources:
+    status: {}
+```
+### Do not use
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: helloworlds.example.com
+spec:
+  group: example.com
+  version: v1
+  names:
+    kind: HelloWorld
+    plural: helloworlds
+    singular: helloworld
+  scope: Namespaced
+  subresources:
+    status: {}
+```
+
+### To try this example follow the below steps 
+
+Create namespace:
+```bash
+kubectl create namespace hello
+```
+Create helloworld crd:
+```bash
+kubectl apply -f crd.yaml
+```
+Create hello-controller:
+```bash
+kubectl apply -f controller.yaml
+```
+Create a configmap of python sync webhook:
+```bash
+kubectl -n hello create configmap hello-controller --from-file=sync.py
+```
+deploy the python webhook:
+```bash
+kubectl -n hello apply -f webhook.yaml
+```
+Create an new helloworld like below:
+```yaml
+apiVersion: example.com/v1
+kind: HelloWorld
+metadata:
+  name: your-name
+spec:
+  who: Your Name
+```
+Check the pod is created or not [Pod and helloworld cr will be in same namespace and will have same name]
+```bash
+kubectl get pods -A
+```
+Check the log of the pod and try to create other helloworld cr or update any helloworld cr. Then check the pod and log.
+
+### Cleanup
+```bash
+kubectl delete helloworld -A --all
+kubectl ns hello
+kubectl delete -f controller.yaml
+kubectl delete -f crd.yaml
+```

--- a/examples/cctl/hello-python/sync.py
+++ b/examples/cctl/hello-python/sync.py
@@ -1,0 +1,45 @@
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+import json
+
+class Controller(BaseHTTPRequestHandler):
+  def sync(self, parent, children):
+    # Compute status based on observed state.
+    desired_status = {
+      "pods": len(children["Pod.v1"])
+    }
+
+    # Generate the desired child object(s).
+    who = parent.get("spec", {}).get("who", "World")
+    desired_pods = [
+      {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+          "name": parent["metadata"]["name"]
+        },
+        "spec": {
+          "restartPolicy": "OnFailure",
+          "containers": [
+            {
+              "name": "hello",
+              "image": "busybox",
+              "command": ["echo", "Hello, %s!" % who]
+            }
+          ]
+        }
+      }
+    ]
+
+    return {"status": desired_status, "children": desired_pods}
+
+  def do_POST(self):
+    # Serve the sync() function as a JSON webhook.
+    observed = json.loads(self.rfile.read(int(self.headers.getheader("content-length"))))
+    desired = self.sync(observed["parent"], observed["children"])
+
+    self.send_response(200)
+    self.send_header("Content-type", "application/json")
+    self.end_headers()
+    self.wfile.write(json.dumps(desired))
+
+HTTPServer(("", 80), Controller).serve_forever()

--- a/examples/cctl/hello-python/sync.py
+++ b/examples/cctl/hello-python/sync.py
@@ -1,45 +1,48 @@
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 
+
 class Controller(BaseHTTPRequestHandler):
-  def sync(self, parent, children):
-    # Compute status based on observed state.
-    desired_status = {
-      "pods": len(children["Pod.v1"])
-    }
-
-    # Generate the desired child object(s).
-    who = parent.get("spec", {}).get("who", "World")
-    desired_pods = [
-      {
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": {
-          "name": parent["metadata"]["name"]
-        },
-        "spec": {
-          "restartPolicy": "OnFailure",
-          "containers": [
-            {
-              "name": "hello",
-              "image": "busybox",
-              "command": ["echo", "Hello, %s!" % who]
-            }
-          ]
+    def sync(self, parent, children):
+        # Compute status based on observed state.
+        desired_status = {
+            "pods": len(children["Pod.v1"])
         }
-      }
-    ]
 
-    return {"status": desired_status, "children": desired_pods}
+        # Generate the desired child object(s).
+        who = parent.get("spec", {}).get("who", "World")
+        desired_pods = [
+            {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": parent["metadata"]["name"]
+                },
+                "spec": {
+                    "restartPolicy": "OnFailure",
+                    "containers": [
+                        {
+                            "name": "hello",
+                            "image": "busybox",
+                            "command": ["echo", "Hello, %s!" % who]
+                        }
+                    ]
+                }
+            }
+        ]
 
-  def do_POST(self):
-    # Serve the sync() function as a JSON webhook.
-    observed = json.loads(self.rfile.read(int(self.headers.getheader("content-length"))))
-    desired = self.sync(observed["parent"], observed["children"])
+        return {"status": desired_status, "children": desired_pods}
 
-    self.send_response(200)
-    self.send_header("Content-type", "application/json")
-    self.end_headers()
-    self.wfile.write(json.dumps(desired))
+    def do_POST(self):
+        # Serve the sync() function as a JSON webhook.
+        observed = json.loads(self.rfile.read(
+            int(self.headers.get("content-length"))))
+        desired = self.sync(observed["parent"], observed["children"])
+
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(desired).encode())
+
 
 HTTPServer(("", 80), Controller).serve_forever()

--- a/examples/cctl/hello-python/webhook.yaml
+++ b/examples/cctl/hello-python/webhook.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-controller
+  template:
+    metadata:
+      labels:
+        app: hello-controller
+    spec:
+      containers:
+        - name: controller
+          image: python:2.7
+          command: ["python", "/hooks/sync.py"]
+          volumeMounts:
+            - name: hooks
+              mountPath: /hooks
+      volumes:
+        - name: hooks
+          configMap:
+            name: hello-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-controller
+spec:
+  selector:
+    app: hello-controller
+  ports:
+    - port: 80

--- a/examples/cctl/hello-python/webhook.yaml
+++ b/examples/cctl/hello-python/webhook.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: controller
-          image: python:2.7
+          image: python:3.7
           command: ["python", "/hooks/sync.py"]
           volumeMounts:
             - name: hooks


### PR DESCRIPTION
If you are using _'CompositeController'_ one basic misconfiguration can lead the controller to continuous reconciliations. When _'CompositeController'_ is used with the parent resource's status **undefined** as a sub-resource, then the reconciliation gets into an infinite loop. This happens since _'CompositeController'_ updates _'status.observedGeneration'_ with _'metadata.generation'_ as part of its reconciliation.

Following sums up the reconciliation logic when status is defined as a sub resource & vice-versa:

1. If parent's status is defined as a sub resource then reconciliation logic patches this status using status api end point. This does not change resource's `metadata.generation` field.
2. If parent's status is not defined as a sub resource then reconciliation logic updates the full parent object. This in turn leads to a update in parent's `metadata.generation` field. This leads to re-triggering of sync hook. In other words this forces the reconciliation to get into a never ending loop.

**Solution**: Add below to watch's CRD
```yaml
  subresources:
    status: {}
```

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>