### PR TITLE
fix(examples): replace k8s.io with example.io

### DIFF
--- a/examples/sample-controller/js/foo.yaml
+++ b/examples/sample-controller/js/foo.yaml
@@ -1,4 +1,4 @@
-apiVersion: samplecontroller.k8s.io/v1alpha1
+apiVersion: samplecontroller.example.io/v1alpha1
 kind: Foo
 metadata:
   name: myfoo

--- a/examples/sample-controller/js/operator.yaml
+++ b/examples/sample-controller/js/operator.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: foos.samplecontroller.k8s.io
+  name: foos.samplecontroller.example.io
 spec:
-  group: samplecontroller.k8s.io
+  group: samplecontroller.example.io
   version: v1alpha1
   scope: Namespaced
   names:
@@ -22,7 +22,7 @@ metadata:
 spec:
   generateSelector: true
   parentResource:
-    apiVersion: samplecontroller.k8s.io/v1alpha1
+    apiVersion: samplecontroller.example.io/v1alpha1
     resource: foos
   childResources:
   - apiVersion: apps/v1

--- a/examples/sample-controller/js/test.sh
+++ b/examples/sample-controller/js/test.sh
@@ -24,7 +24,7 @@ trap cleanup EXIT
 # Uncomment below if debug / verbose execution is needed
 #set -ex
 
-my_crd="foos.samplecontroller.k8s.io"
+my_crd="foos.samplecontroller.example.io"
 my_deploy="my-deploy"
 
 echo -e "\n Install SampleController..."


### PR DESCRIPTION
fixes https://github.com/AmitKumarDas/metac/issues/127

In newer kubernetes version, the namespace k8s.io is protected
https://github.com/kubernetes/enhancements/pull/1111

switch sample controller to use example.io instead

Signed-off-by: Florian Koch <flo@ctrl.wtf>