### PR TITLE
feat(discovery): add method to list resources based on kind

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v2
       - name: setup env
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Setup go
         uses: actions/setup-go@v1
         with:

--- a/dynamic/discovery/discovery.go
+++ b/dynamic/discovery/discovery.go
@@ -334,3 +334,19 @@ func (d *APIResourceDiscovery) StartIfNotAlready() bool {
 	d.isStarted = true
 	return true
 }
+
+// GetAPIResourcesForKind returns the list of discovered API resources
+// corresponding to the provided kind
+func (d *APIResourceDiscovery) GetAPIResourcesForKind(kind string) []*metav1.APIResource {
+	var apiResources []*metav1.APIResource
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	for _, apiResourceRegistery := range d.discoveredResources {
+		apiResource, isExist := apiResourceRegistery.kinds[kind]
+		if isExist {
+			apiResources = append(apiResources, &apiResource.APIResource)
+		}
+	}
+	return apiResources
+}


### PR DESCRIPTION
This PR does the following changes
- Adds functionality to discover the list of resources based
on their kind. This functionality will help consumers to get
resource details if they are aware of Resource Kind.
- Updates the way of configuring GitHub WorkFlow
   Path and Envs(For more info click [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)).

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>